### PR TITLE
Refactor to use injected state

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,12 @@
-"""Compatibility wrapper importing the main application components."""
-from server.api import app, GenerateImageRequest, ChatRequest, AnalyzeImageRequest, run_mcp_server
+"""Compatibility wrapper that provides a ready-to-use FastAPI app and helpers."""
+from server.api import create_api_app, GenerateImageRequest, ChatRequest, AnalyzeImageRequest, run_mcp_server
 from ui.web import create_gradio_app
-import core.sdxl as sdxl
-import core.ollama as ollama
+from core.state import AppState
 from core.sdxl import (
     generate_image,
     init_sdxl,
     save_to_gallery,
     get_latest_image,
-    sdxl_pipe,
     TEMP_DIR,
     GALLERY_DIR,
 )
@@ -18,12 +16,14 @@ from core.ollama import (
     generate_prompt,
     analyze_image,
     init_ollama,
-    ollama_model,
-    chat_history_store,
 )
-from core.memory import clear_cuda_memory, get_model_status, model_status, latest_generated_image
+from core.memory import clear_cuda_memory, get_model_status
+
+# Single application state used when this module is imported
+app_state = AppState()
+app = create_api_app(app_state)
 
 
 def initialize_models():
-    init_sdxl()
-    init_ollama()
+    init_sdxl(app_state)
+    init_ollama(app_state)

--- a/core/memory.py
+++ b/core/memory.py
@@ -2,11 +2,10 @@ import gc
 import logging
 import torch
 
+from .state import AppState
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
-
-model_status = {"sdxl": False, "ollama": False, "multimodal": False}
-latest_generated_image = None
 
 
 def clear_cuda_memory():
@@ -18,11 +17,11 @@ def clear_cuda_memory():
     logger.info("CUDA memory cleared and garbage collection performed")
 
 
-def get_model_status():
+def get_model_status(state: AppState) -> str:
     """Return formatted Markdown describing current model availability."""
     status_text = "🤖 **Model Status:**\n"
-    status_text += f"• SDXL: {'✅ Loaded' if model_status['sdxl'] else '❌ Not loaded'}\n"
-    status_text += f"• Ollama: {'✅ Connected' if model_status['ollama'] else '❌ Not connected'}\n"
-    status_text += f"• Vision: {'✅ Available' if model_status['multimodal'] else '❌ Not available'}\n"
+    status_text += f"• SDXL: {'✅ Loaded' if state.model_status['sdxl'] else '❌ Not loaded'}\n"
+    status_text += f"• Ollama: {'✅ Connected' if state.model_status['ollama'] else '❌ Not connected'}\n"
+    status_text += f"• Vision: {'✅ Available' if state.model_status['multimodal'] else '❌ Not available'}\n"
     status_text += f"• CUDA: {'✅ Available' if torch.cuda.is_available() else '❌ Not available'}"
     return status_text

--- a/core/state.py
+++ b/core/state.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Dict, List, Tuple
+from PIL import Image
+from diffusers import StableDiffusionXLPipeline
+
+@dataclass
+class AppState:
+    """Holds runtime objects for the application."""
+
+    sdxl_pipe: Optional[StableDiffusionXLPipeline] = None
+    ollama_model: Optional[str] = None
+    model_status: Dict[str, bool] = field(
+        default_factory=lambda: {"sdxl": False, "ollama": False, "multimodal": False}
+    )
+    chat_history_store: Dict[str, List[Tuple[str, str]]] = field(default_factory=dict)
+    latest_generated_image: Optional[Image.Image] = None

--- a/server/api.py
+++ b/server/api.py
@@ -1,8 +1,7 @@
 import base64
 import io
 import logging
-
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Request
 from pydantic import BaseModel
 from PIL import Image
 import torch
@@ -10,7 +9,7 @@ import torch
 from core import sdxl, ollama
 from core.sdxl import generate_image
 from core.ollama import chat_completion, analyze_image
-from core.memory import model_status
+from core.state import AppState
 
 logger = logging.getLogger(__name__)
 
@@ -35,69 +34,73 @@ class AnalyzeImageRequest(BaseModel):
     question: str = "Describe this image in detail"
 
 
-app = FastAPI(title="Illustrious AI MCP Server", version="1.0.0")
+def create_api_app(state: AppState) -> FastAPI:
+    app = FastAPI(title="Illustrious AI MCP Server", version="1.0.0")
+    app.state.app_state = state
+
+    def get_state(request: Request) -> AppState:
+        return request.app.state.app_state
+
+    @app.on_event("startup")
+    async def startup_event():
+        if state.sdxl_pipe is None:
+            sdxl.init_sdxl(state)
+        if state.ollama_model is None:
+            ollama.init_ollama(state)
+
+    @app.get("/status")
+    async def server_status(state: AppState = Depends(get_state)):
+        return {
+            "status": "running",
+            "models": state.model_status,
+            "cuda_available": torch.cuda.is_available(),
+        }
+
+    @app.post("/generate-image")
+    async def mcp_generate_image(request: GenerateImageRequest, state: AppState = Depends(get_state)):
+        if state.sdxl_pipe is None:
+            raise HTTPException(status_code=503, detail="SDXL model not available")
+        image, status_msg = generate_image(
+            state,
+            request.prompt,
+            request.negative_prompt,
+            request.steps,
+            request.guidance,
+            request.seed,
+        )
+        if image is None:
+            code = 507 if "out of memory" in status_msg.lower() else 500
+            raise HTTPException(status_code=code, detail=status_msg)
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        img_base64 = base64.b64encode(buffered.getvalue()).decode()
+        return {"success": True, "image_base64": img_base64, "message": status_msg}
+
+    @app.post("/chat")
+    async def mcp_chat(request: ChatRequest, state: AppState = Depends(get_state)):
+        if state.ollama_model is None:
+            raise HTTPException(status_code=503, detail="Ollama model not available")
+        messages = [{"role": "user", "content": request.message}]
+        response = chat_completion(state, messages, request.temperature, request.max_tokens)
+        return {"response": response, "session_id": request.session_id}
+
+    @app.post("/analyze-image")
+    async def mcp_analyze_image(request: AnalyzeImageRequest, state: AppState = Depends(get_state)):
+        if state.ollama_model is None or not state.model_status["multimodal"]:
+            raise HTTPException(status_code=503, detail="Ollama vision model not available")
+        try:
+            image_data = base64.b64decode(request.image_base64)
+            image = Image.open(io.BytesIO(image_data))
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid image data: {e}")
+        analysis = analyze_image(state, image, request.question)
+        return {"analysis": analysis}
+
+    return app
 
 
-@app.on_event("startup")
-async def startup_event():
-    if sdxl.sdxl_pipe is None:
-        sdxl.init_sdxl()
-    if ollama.ollama_model is None:
-        ollama.init_ollama()
-
-
-@app.get("/status")
-async def server_status():
-    return {
-        "status": "running",
-        "models": model_status,
-        "cuda_available": torch.cuda.is_available(),
-    }
-
-
-@app.post("/generate-image")
-async def mcp_generate_image(request: GenerateImageRequest):
-    if sdxl.sdxl_pipe is None:
-        raise HTTPException(status_code=503, detail="SDXL model not available")
-    image, status = generate_image(
-        request.prompt,
-        request.negative_prompt,
-        request.steps,
-        request.guidance,
-        request.seed,
-    )
-    if image is None:
-        code = 507 if "out of memory" in status.lower() else 500
-        raise HTTPException(status_code=code, detail=status)
-    buffered = io.BytesIO()
-    image.save(buffered, format="PNG")
-    img_base64 = base64.b64encode(buffered.getvalue()).decode()
-    return {"success": True, "image_base64": img_base64, "message": status}
-
-
-@app.post("/chat")
-async def mcp_chat(request: ChatRequest):
-    if ollama.ollama_model is None:
-        raise HTTPException(status_code=503, detail="Ollama model not available")
-    messages = [{"role": "user", "content": request.message}]
-    response = chat_completion(messages, request.temperature, request.max_tokens)
-    return {"response": response, "session_id": request.session_id}
-
-
-@app.post("/analyze-image")
-async def mcp_analyze_image(request: AnalyzeImageRequest):
-    if ollama.ollama_model is None or not model_status["multimodal"]:
-        raise HTTPException(status_code=503, detail="Ollama vision model not available")
-    try:
-        image_data = base64.b64decode(request.image_base64)
-        image = Image.open(io.BytesIO(image_data))
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Invalid image data: {e}")
-    analysis = analyze_image(image, request.question)
-    return {"analysis": analysis}
-
-
-def run_mcp_server():
+def run_mcp_server(state: AppState) -> None:
     import uvicorn
 
+    app = create_api_app(state)
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -56,13 +56,13 @@ def dummy_analyze_image(image, question=""):
 @pytest.fixture(autouse=True)
 def setup_app(monkeypatch):
     app = load_app()
-    monkeypatch.setattr(app.sdxl, 'sdxl_pipe', DummyPipe())
-    monkeypatch.setattr(app.ollama, 'ollama_model', 'dummy')
-    app.model_status.update({'sdxl': True, 'ollama': True, 'multimodal': True})
+    app.app_state.sdxl_pipe = DummyPipe()
+    app.app_state.ollama_model = 'dummy'
+    app.app_state.model_status.update({'sdxl': True, 'ollama': True, 'multimodal': True})
     import server.api as api
-    monkeypatch.setattr(api, 'generate_image', lambda *a, **k: (Image.new('RGB',(64,64),'blue'), 'done'))
-    monkeypatch.setattr(api, 'chat_completion', dummy_chat_completion)
-    monkeypatch.setattr(api, 'analyze_image', dummy_analyze_image)
+    monkeypatch.setattr(api, 'generate_image', lambda state, *a, **k: (Image.new('RGB',(64,64),'blue'), 'done'))
+    monkeypatch.setattr(api, 'chat_completion', lambda state, *a, **k: dummy_chat_completion(*a, **k))
+    monkeypatch.setattr(api, 'analyze_image', lambda state, img, q='': dummy_analyze_image(img, q))
     monkeypatch.setattr(app, 'clear_cuda_memory', lambda: None)
     monkeypatch.setattr(sys.modules['__main__'], 'app', app, raising=False)
     yield

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -52,15 +52,15 @@ def patch_clear_cuda(monkeypatch):
 
 def test_generate_image_no_model(monkeypatch):
     app = load_app()
-    monkeypatch.setattr(app.sdxl, 'sdxl_pipe', None)
-    image, status = app.generate_image('test')
+    app.app_state.sdxl_pipe = None
+    image, status = app.generate_image(app.app_state, 'test')
     assert image is None
     assert 'model not loaded' in status.lower()
 
 
 def test_generate_image_success(monkeypatch):
     app = load_app()
-    monkeypatch.setattr(app.sdxl, 'sdxl_pipe', DummyPipe())
-    img, status = app.generate_image('test prompt', save_to_gallery_flag=False)
+    app.app_state.sdxl_pipe = DummyPipe()
+    img, status = app.generate_image(app.app_state, 'test prompt', save_to_gallery_flag=False)
     assert isinstance(img, Image.Image)
     assert 'successfully' in status.lower()


### PR DESCRIPTION
## Summary
- create `AppState` dataclass for runtime model state
- update API to depend on the `AppState`
- refactor SDXL and Ollama helpers to take state
- pass state to Gradio UI builder
- adjust tests for dependency injection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f76f78b248328b1f630821f1d53fc