### PR TITLE
Add tests for config and initialization error cases

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -119,3 +119,27 @@ def test_concurrent_requests():
         futures = [ex.submit(send, i) for i in range(10)]
         results = [f.result() for f in as_completed(futures)]
     assert all(r == 200 for r in results)
+
+def test_generate_image_endpoint_no_model():
+    app = load_app()
+    app.app_state.sdxl_pipe = None
+    client = TestClient(app.app)
+    resp = client.post('/generate-image', json={"prompt": "x"})
+    assert resp.status_code == 503
+
+
+def test_chat_endpoint_no_model():
+    app = load_app()
+    app.app_state.ollama_model = None
+    client = TestClient(app.app)
+    resp = client.post('/chat', json={"message": "hi"})
+    assert resp.status_code == 503
+
+
+def test_analyze_image_invalid_input():
+    app = load_app()
+    client = TestClient(app.app)
+    app.app_state.ollama_model = 'dummy'
+    app.app_state.model_status['multimodal'] = True
+    resp = client.post('/analyze-image', json={"image_base64": "notbase64"})
+    assert resp.status_code == 400

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+import pytest
+
+from core import config
+
+
+def test_load_config_file_and_env(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "sd_model: '/tmp/model.pt'\nollama_model: 'test-model'\nollama_base_url: 'http://example.com'"
+    )
+    monkeypatch.setenv("SD_MODEL", "/env/model.pt")
+    conf = config.load_config(str(cfg))
+    assert conf.sd_model == "/env/model.pt"
+    assert conf.ollama_model == "test-model"
+    assert conf.ollama_base_url == "http://example.com"
+
+
+def test_init_sdxl_missing_model(tmp_path, monkeypatch):
+    from core import sdxl
+    from core.state import AppState
+    state = AppState()
+    monkeypatch.setattr(sdxl.CONFIG, "sd_model", str(tmp_path / "missing.safetensors"))
+    result = sdxl.init_sdxl(state)
+    assert result is None
+    assert state.sdxl_pipe is None
+    assert state.model_status["sdxl"] is False
+
+
+def test_init_ollama_no_model(monkeypatch):
+    from core import ollama
+    from core.state import AppState
+    state = AppState()
+
+    class Resp:
+        status_code = 200
+        def json(self):
+            return {"models": [{"name": "other"}]}
+
+    monkeypatch.setattr(ollama.requests, "get", lambda *a, **k: Resp())
+    monkeypatch.setattr(ollama.requests, "post", lambda *a, **k: Resp())
+    monkeypatch.setattr(ollama.CONFIG, "ollama_model", "missing")
+    result = ollama.init_ollama(state)
+    assert result is None
+    assert state.model_status["ollama"] is False


### PR DESCRIPTION
## Summary
- cover configuration loading logic
- add initialization error tests for SDXL and Ollama
- exercise server endpoints error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7936748083288cb0a32bd1d3ec6c