### PR TITLE
Fix config path placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
    ```
 
 4. **Configure models**
-   Edit `config.yaml` or set environment variables:
+   Copy `config.yaml` to your workspace and edit it or set environment variables:
    ```yaml
    sd_model: "/path/to/your/sdxl-model.safetensors"
    ollama_model: "qwen2.5:7b"  # Your Ollama model
@@ -151,7 +151,7 @@ python examples/api_examples/batch_generate.py
 ## ⚙️ Configuration
 
 ### Model Paths
-Edit `config.yaml` to set your model locations or use environment variables:
+Copy `config.yaml` and adjust the paths to your environment, or use environment variables:
 - `sd_model` (`SD_MODEL`): Path to SDXL .safetensors file
 - `ollama_model` (`OLLAMA_MODEL`): Ollama model name
 - `ollama_base_url` (`OLLAMA_BASE_URL`): Ollama server URL

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,3 @@
-sd_model: "/home/ant/AI/Project/SDXL Models/waiNSFWIllustrious_v140.safetensors"
+sd_model: "/path/to/sdxl-model.safetensors"
 ollama_model: "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"
 ollama_base_url: "http://localhost:11434"


### PR DESCRIPTION
## Summary
- use a placeholder path in `config.yaml`
- document that `config.yaml` is an example and should be copied and edited

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7fb66890832887cbe147cddcf56c