### PR TITLE
Add model switching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
 - **SDXL Image Generation**: High-quality 1024x1024 image generation using Stable Diffusion XL
 - **Ollama LLM Chat**: Interactive chat with local language models
 - **Cross-Tab Integration**: Generate images directly from chat using `#generate` commands
+- **Dynamic Model Switching**: Swap SDXL or Ollama models without restarting
 
 ### 🚀 **Advanced Memory Management**
 - **Automatic CUDA Memory Management**: Smart memory clearing and retry logic
@@ -134,6 +135,13 @@ curl -X POST http://localhost:8000/chat \
 curl http://localhost:8000/status
 ```
 
+#### Switch Models
+```bash
+curl -X POST http://localhost:8000/switch-models \
+  -H "Content-Type: application/json" \
+  -d '{"sd_model": "/path/to/model.safetensors", "ollama_model": "qwen:7b"}'
+```
+
 ## 🧪 Testing
 
 ### Automated Testing
@@ -210,6 +218,7 @@ Project/
 | `/generate-image` | POST | Generate images with SDXL |
 | `/chat` | POST | Chat with Ollama LLM |
 | `/analyze-image` | POST | Analyze images (if vision model available) |
+| `/switch-models` | POST | Switch SDXL and/or Ollama models |
 
 ### Response Codes
 - `200`: Success

--- a/core/ollama.py
+++ b/core/ollama.py
@@ -55,6 +55,17 @@ def _get_model_path() -> str:
     return CONFIG.ollama_model
 
 
+def switch_ollama_model(state: AppState, name: str) -> bool:
+    """Switch the active Ollama model."""
+    state.ollama_model = None
+    state.model_status["ollama"] = False
+    state.model_status["multimodal"] = False
+    state.chat_history_store.clear()
+    CONFIG.ollama_model = name
+    logger.info("Switching Ollama model to %s", name)
+    return init_ollama(state) is not None
+
+
 def chat_completion(state: AppState, messages: List[dict], temperature: float = 0.7, max_tokens: int = 256) -> str:
     if not state.ollama_model:
         return "❌ Ollama model not loaded. Please check your Ollama setup."

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -127,3 +127,15 @@ def generate_image(
 def get_latest_image(state: AppState) -> Optional[Image.Image]:
     """Return the last generated image."""
     return state.latest_generated_image
+
+
+def switch_sdxl_model(state: AppState, path: str) -> bool:
+    """Switch to a different SDXL checkpoint."""
+    if not os.path.exists(path):
+        logger.error("SDXL model not found: %s", path)
+        return False
+    state.sdxl_pipe = None
+    clear_cuda_memory()
+    CONFIG.sd_model = path
+    logger.info("Switching SDXL model to %s", path)
+    return init_sdxl(state) is not None

--- a/server/api.py
+++ b/server/api.py
@@ -34,6 +34,11 @@ class AnalyzeImageRequest(BaseModel):
     question: str = "Describe this image in detail"
 
 
+class SwitchModelsRequest(BaseModel):
+    sd_model: str | None = None
+    ollama_model: str | None = None
+
+
 def create_api_app(state: AppState) -> FastAPI:
     app = FastAPI(title="Illustrious AI MCP Server", version="1.0.0")
     app.state.app_state = state
@@ -95,6 +100,15 @@ def create_api_app(state: AppState) -> FastAPI:
             raise HTTPException(status_code=400, detail=f"Invalid image data: {e}")
         analysis = analyze_image(state, image, request.question)
         return {"analysis": analysis}
+
+    @app.post("/switch-models")
+    async def mcp_switch_models(request: SwitchModelsRequest, state: AppState = Depends(get_state)):
+        result = {}
+        if request.sd_model:
+            result["sdxl"] = sdxl.switch_sdxl_model(state, request.sd_model)
+        if request.ollama_model:
+            result["ollama"] = ollama.switch_ollama_model(state, request.ollama_model)
+        return {"models": state.model_status, **result}
 
     return app
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -143,3 +143,15 @@ def test_analyze_image_invalid_input():
     app.app_state.model_status['multimodal'] = True
     resp = client.post('/analyze-image', json={"image_base64": "notbase64"})
     assert resp.status_code == 400
+
+
+def test_switch_models_endpoint(monkeypatch):
+    client = get_client()
+    calls = {}
+    import server.api as api
+    monkeypatch.setattr(api.sdxl, 'switch_sdxl_model', lambda state, p: calls.setdefault('sdxl', p) or True)
+    monkeypatch.setattr(api.ollama, 'switch_ollama_model', lambda state, n: calls.setdefault('ollama', n) or True)
+    resp = client.post('/switch-models', json={"sd_model": "a", "ollama_model": "b"})
+    assert resp.status_code == 200
+    assert calls['sdxl'] == 'a'
+    assert calls['ollama'] == 'b'

--- a/ui/web.py
+++ b/ui/web.py
@@ -63,6 +63,10 @@ def create_gradio_app(state: AppState):
         with gr.Tab("📊 System Info"):
             gr.Markdown("### Model Configuration")
             config_display = gr.Code(value=json.dumps(CONFIG.as_dict(), indent=2), language="json", label="Configuration")
+            with gr.Row():
+                sd_model_input = gr.Textbox(value=CONFIG.sd_model, label="SDXL Model Path")
+                ollama_model_input = gr.Textbox(value=CONFIG.ollama_model, label="Ollama Model")
+            switch_btn = gr.Button("🔄 Switch Models", variant="primary")
             refresh_btn = gr.Button("🔄 Refresh Status", variant="secondary")
             gr.Markdown("### CUDA Memory Management")
             gr.Markdown(
@@ -119,5 +123,12 @@ def create_gradio_app(state: AppState):
         clear_btn.click(lambda: ([], ""), outputs=[chatbot, msg])
         if state.model_status["multimodal"]:
             analyze_btn.click(fn=lambda img, q: analyze_image(state, img, q), inputs=[input_image, analysis_question], outputs=analysis_output)
+        def do_switch(sd_path, ollama_name):
+            if sd_path:
+                sdxl.switch_sdxl_model(state, sd_path)
+            if ollama_name:
+                ollama.switch_ollama_model(state, ollama_name)
+            return get_model_status(state), json.dumps(CONFIG.as_dict(), indent=2)
+        switch_btn.click(fn=do_switch, inputs=[sd_model_input, ollama_model_input], outputs=[status_display, config_display])
         refresh_btn.click(fn=lambda: get_model_status(state), outputs=status_display)
     return demo


### PR DESCRIPTION
## Summary
- allow hot-switching of SDXL and Ollama models
- expose `/switch-models` endpoint in API
- add UI controls for model switching
- cover new functionality with tests
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f87bc86888328960a83dc568623f1