### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ curl -X POST http://localhost:8000/switch-models \
 
 ## 🧪 Testing
 
+Before running the test suite, install the dependencies:
+```bash
+pip install -r requirements.txt httpx
+```
+Skipping these installations will result in import errors when running `pytest`.
+
 ### Automated Testing
 ```bash
 cd examples/api_examples


### PR DESCRIPTION
## Summary
- clarify dependency installation before running pytest

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_683f8a15ba648328aa88a20395a596c7