### PR TITLE
Add dev test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ python test_simple.py
 python test_full_functionality.py
 ```
 
+#### Developer Testing
+Install the extra packages needed by the test suite (`pytest`, `Pillow`, `PyYAML`, etc.):
+
+```bash
+pip install -r requirements-test.txt
+```
+
+Then run:
+
+```bash
+pytest
+```
+
 ## 💻 Web Interface
 
 ### 🎨 Text-to-Image Tab

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+pytest>=7.0
+Pillow>=9.0.0,<11.0.0
+PyYAML>=6.0,<7.0
+httpx>=0.27
+


### PR DESCRIPTION
## Summary
- add `requirements-test.txt` with `pytest`, `Pillow`, `PyYAML`, and `httpx`
- document developer testing steps and package installation in README

## Testing
- `pip install -r requirements-test.txt` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684a4979f320832892bddd6bade6b9a7