### PR TITLE
Update docs for GPU neutrality and testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This file provides guidance to Claude (or other AI assistants) when working with
 ### Architecture
 
 - **Triple AI System**: SDXL (images), Ollama LLM (text), Vision models (analysis)
-- **Memory Management**: Automatic CUDA handling with retry logic, plus manual model manager
+- **Memory Management**: Automatic GPU memory handling (CUDA/ROCm) with retry logic, plus manual model manager
 - **Cross-Feature Integration**: Generate images from chat, analyze generated images
 - **Session Management**: Persistent chat history with context preservation
 
@@ -69,7 +69,7 @@ This file provides guidance to Claude (or other AI assistants) when working with
   - Interactive and CLI modes
 
 - **`verify_setup.py`**: System verification
-  - Checks Python, CUDA, dependencies
+  - Checks Python, CUDA/ROCm, dependencies
   - Verifies Ollama and model files
   - Generates setup report
 
@@ -95,6 +95,9 @@ python model_manager.py --balanced    # For mixed usage
 ```bash
 # Verify setup
 python verify_setup.py
+
+# Install test dependencies
+pip install -r requirements-test.txt
 
 # Test functionality
 python test_simple.py              # Recommended
@@ -138,7 +141,7 @@ Environment variables override config:
 ### Memory Management
 
 1. **Automatic handling**:
-   - Pre/post generation CUDA clearing
+   - Pre/post generation GPU cache clearing
    - Retry on OOM (up to 2 attempts)
    - Garbage collection integration
 
@@ -149,7 +152,7 @@ Environment variables override config:
 
 ### Error Handling
 
-- **CUDA OOM**: Automatic retry with memory clearing
+- **GPU OOM**: Automatic retry with memory clearing
 - **Model loading**: Comprehensive error messages
 - **API errors**: Proper HTTP status codes (500, 503, 507)
 - **Ollama connection**: Timeout and validation
@@ -163,7 +166,7 @@ Environment variables override config:
 
 ## Common Issues and Solutions
 
-### CUDA Out of Memory
+### GPU Out of Memory (CUDA/ROCm)
 1. Run `python model_manager.py --image-mode` before generation
 2. Set `export OLLAMA_KEEP_ALIVE=0`
 3. Reduce image size or steps

--- a/SETUP_COMPLETE.md
+++ b/SETUP_COMPLETE.md
@@ -20,8 +20,8 @@ Your AI Studio is now fully configured and tested with all features working corr
 - Status: ✅ Working perfectly
 
 ### 4. **Hardware**
-- GPU: NVIDIA RTX 4090 Laptop GPU (16GB VRAM)
-- CUDA: 12.6
+- GPU: NVIDIA or AMD with 16GB+ VRAM
+- Backend: CUDA or ROCm
 - Status: ✅ Optimized for your hardware
 
 ## 🚀 Quick Start Commands
@@ -62,7 +62,7 @@ python model_manager.py --status        # Check GPU status
 
 1. **Memory Management**
    - Use `model_manager.py` to switch between image and LLM modes
-   - The system automatically handles CUDA memory, but switching modes helps with 16GB VRAM
+   - The system automatically manages GPU memory, but switching modes helps with 16GB VRAM
 
 2. **Image Generation**
    - Default: 1024x1024 resolution
@@ -80,7 +80,7 @@ python model_manager.py --status        # Check GPU status
 
 ## 🔧 Configuration
 
-Your setup uses optimal settings for RTX 4090M:
+Your setup uses optimal settings for high-end GPUs (e.g., RTX 4090M):
 - FP16 precision for speed
 - TF32 enabled for accuracy
 - 95% VRAM utilization
@@ -99,7 +99,7 @@ Your setup uses optimal settings for RTX 4090M:
 
 ## 🛠️ Troubleshooting
 
-### If you encounter CUDA OOM errors:
+### If you encounter GPU OOM errors (CUDA/ROCm):
 1. Run `python model_manager.py --image-mode` before generating images
 2. Set environment variable: `export OLLAMA_KEEP_ALIVE=0`
 3. Reduce image resolution or batch size
@@ -111,7 +111,7 @@ Your setup uses optimal settings for RTX 4090M:
 
 ## 📊 Performance Benchmarks
 
-With your RTX 4090M:
+Example performance with RTX 4090M:
 - Image Generation: ~7-10 seconds per image (1024x1024, 30 steps)
 - LLM Response: ~1-3 seconds for typical prompts
 - Vision Analysis: ~2-5 seconds per image

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,11 @@ examples/
 
 ## 🚀 Quick Start
 
+Before running the examples, make sure the main project is installed using:
+```bash
+python ../setup_env.py
+```
+
 ### 1. Test the API
 ```bash
 cd api_examples
@@ -186,7 +191,7 @@ curl -X POST http://localhost:8000/chat \
    ```
 
 3. **Image Generation Fails:**
-   - Check CUDA availability
+   - Check GPU availability (`nvidia-smi` or `rocm-smi`)
    - Verify SDXL model is loaded
    - Restart application to reload models
 

--- a/examples/examples_folder.md
+++ b/examples/examples_folder.md
@@ -46,8 +46,8 @@ def create_deployment_guide():
 ## Detailed Setup
 
 ### Prerequisites
-- Docker with GPU support (nvidia-docker2)
-- CUDA-compatible GPU with 12GB+ VRAM
+- Docker with GPU support (nvidia-docker2 or ROCm)
+- CUDA or ROCm compatible GPU with 12GB+ VRAM
 - 20GB+ disk space
 
 ### Build Options
@@ -506,7 +506,7 @@ Common issues and solutions for AI Studio setup and usage.
 
 ## Installation Issues
 
-### CUDA Out of Memory
+### GPU Out of Memory (CUDA/ROCm)
 **Problem:** GPU runs out of memory during model loading or generation.
 
 **Solutions:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,13 +31,16 @@ PyYAML>=6.0,<7.0
 # Utilities
 numpy>=1.21.0,<2.0.0
 
-# CUDA Installation Note:
-# For CUDA support, install PyTorch with CUDA manually:
-# pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+# GPU Installation Note:
+# For CUDA or ROCm support, install the appropriate PyTorch build manually:
+# CUDA:
+#   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+# ROCm:
+#   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7
 
 # Manual Installation Commands:
 # 1. Create conda environment: conda create -n ai-studio python=3.10
 # 2. Activate environment: conda activate ai-studio  
-# 3. Install CUDA PyTorch: pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+# 3. Install PyTorch with CUDA or ROCm as needed
 # 4. Install other requirements: pip install -r requirements.txt
 # 5. Ensure Ollama is running: ollama serve (in separate terminal)


### PR DESCRIPTION
## Summary
- clarify GPU memory management wording in CLAUDE.md
- document installing test dependencies
- make setup guide generic for CUDA/ROCm hardware
- note `setup_env.py` in examples README
- update examples troubleshooting steps for GPU
- revise requirements comment for CUDA/ROCm installs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684a4419ece88328992d9b28379929e3