### PR TITLE
Add lazy loading and manual model controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ recommend at least **16GB** of VRAM for smooth 1024x1024 generation. Lower VRAM
 ```bash
 python main.py
 ```
+Add `--lazy-load` to defer model initialization until first use:
+```bash
+python main.py --lazy-load
+```
 Then open: http://localhost:7860
 
 ### Memory Management
@@ -172,6 +176,7 @@ pytest
 - Model configuration and status
 - Switch models on the fly
 - View API documentation
+- **Load Models On Demand** buttons for SDXL and Ollama
 
 ## 🔧 API Usage
 
@@ -228,6 +233,7 @@ ollama_model: "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"
 ollama_vision_model: "qwen2.5vl:7b"
 ollama_base_url: "http://localhost:11434"
 gpu_backend: "cuda"  # "cuda", "rocm", or "cpu"
+load_models_on_startup: true  # Set false for on-demand loading
 
 cuda_settings:
   device: "cuda:0"

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ ollama_model: "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"  # Ollama model name fo
 ollama_vision_model: "qwen2.5vl:7b"  # Vision-language model for image analysis and Q&A
 ollama_base_url: "http://localhost:11434"  # Ollama API endpoint (default local installation)
 gpu_backend: "cuda"  # "cuda", "rocm", or "cpu"
+load_models_on_startup: true  # Set false to load models on demand
 
 # Performance settings optimized for RTX 4090M (16GB VRAM)
 # Adjust these based on your GPU memory and performance requirements

--- a/core/config.py
+++ b/core/config.py
@@ -15,6 +15,7 @@ class AppConfig:
     cuda_settings: dict = None
     generation_defaults: dict = None
     gpu_backend: str = "cuda"
+    load_models_on_startup: bool = True
 
     def __post_init__(self):
         if self.cuda_settings is None:
@@ -52,6 +53,9 @@ def load_config(path: str | None = None) -> AppConfig:
     config.ollama_model = os.getenv("OLLAMA_MODEL", config.ollama_model)
     config.ollama_base_url = os.getenv("OLLAMA_BASE_URL", config.ollama_base_url)
     config.gpu_backend = os.getenv("GPU_BACKEND", config.gpu_backend)
+    env_lazy = os.getenv("LOAD_MODELS_ON_STARTUP")
+    if env_lazy is not None:
+        config.load_models_on_startup = env_lazy.lower() not in ("false", "0", "no")
     return config
 
 

--- a/main.py
+++ b/main.py
@@ -83,12 +83,12 @@ def initialize_models() -> None:
         logger.error(f"Traceback: {traceback.format_exc()}")
         raise
 
-def start_mcp_server() -> threading.Thread:
+def start_mcp_server(lazy_load: bool = False) -> threading.Thread:
     """Start the MCP server in a separate thread."""
     def run_server():
         try:
             logger.info("Starting MCP Server...")
-            run_mcp_server(app_state)
+            run_mcp_server(app_state, auto_load=not lazy_load)
         except Exception as e:
             logger.error(f"MCP Server error: {e}")
             logger.error(f"Traceback: {traceback.format_exc()}")
@@ -119,16 +119,21 @@ def start_web_interface():
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Illustrious AI Studio")
+    parser.add_argument("--lazy-load", action="store_true", help="Defer model initialization until requested")
+    args = parser.parse_args()
+
     try:
         logger.info("=" * 50)
         logger.info("🎨 Starting Illustrious AI Studio")
         logger.info("=" * 50)
-        
-        # Initialize models
-        initialize_models()
-        
-        # Start MCP server
-        mcp_thread = start_mcp_server()
+
+        if not args.lazy_load:
+            initialize_models()
+
+        mcp_thread = start_mcp_server(lazy_load=args.lazy_load)
         
         # Start web interface
         logger.info("🌐 Starting web interface on http://localhost:7860")

--- a/ui/web.py
+++ b/ui/web.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 import gradio as gr
 
-from core.sdxl import generate_image, TEMP_DIR, get_latest_image
+from core.sdxl import generate_image, TEMP_DIR, get_latest_image, init_sdxl
 from core.config import CONFIG
-from core.ollama import generate_prompt, handle_chat, analyze_image
+from core.ollama import generate_prompt, handle_chat, analyze_image, init_ollama
 from core.memory import get_model_status
 from core.state import AppState
 from core.prompt_templates import template_manager
@@ -319,6 +319,16 @@ def create_gradio_app(state: AppState):
                 variant="secondary",
                 elem_classes=["secondary-button"]
             )
+            load_sdxl_btn = gr.Button(
+                "⚡ Load SDXL",
+                variant="secondary",
+                elem_classes=["secondary-button"]
+            )
+            load_ollama_btn = gr.Button(
+                "⚡ Load Ollama",
+                variant="secondary",
+                elem_classes=["secondary-button"]
+            )
             gr.Markdown("### CUDA Memory Management")
             gr.Markdown(
                 """
@@ -559,4 +569,6 @@ def create_gradio_app(state: AppState):
             return get_model_status(state), json.dumps(CONFIG.as_dict(), indent=2)
         switch_btn.click(fn=do_switch, inputs=[sd_model_input, ollama_model_input], outputs=[status_display, config_display])
         refresh_btn.click(fn=lambda: get_model_status(state), outputs=status_display)
+        load_sdxl_btn.click(fn=lambda: (sdxl.init_sdxl(state), get_model_status(state))[1], outputs=status_display)
+        load_ollama_btn.click(fn=lambda: (ollama.init_ollama(state), get_model_status(state))[1], outputs=status_display)
     return demo


### PR DESCRIPTION
## Summary
- allow lazy model loading via new `--lazy-load` CLI option
- make MCP startup optionally load models
- add manual load buttons on System Info tab
- document new flag and UI controls
- expose config flag `load_models_on_startup`

## Testing
- `pytest -q` *(fails: Client.__init__() got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684abce017bc8328a8797f3daae3f773