### PR TITLE
Add MCP tool chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ pytest
 ### 💬 AI Chat Tab
 - Chat with the LLM
 - Use `#generate <description>` to create images
+- Call MCP tools with `/tool <server>.<method> key=value`
 - Maintains conversation history
 
 ### 🔍 Image Analysis Tab
@@ -212,6 +213,12 @@ curl -X POST http://localhost:8000/chat \
     "message": "Tell me about cats",
     "session_id": "default"
   }'
+```
+### MCP Tool Example
+```bash
+curl -X POST http://localhost:8001/tools/read_file \
+  -H "Content-Type: application/json" \
+  -d '{"arguments": {"path": "/tmp/foo.txt"}}'
 ```
 
 ### Image Analysis

--- a/core/mcp_tools.py
+++ b/core/mcp_tools.py
@@ -24,7 +24,7 @@ def call_tool(server: str, tool: str, **kwargs: Any) -> str:
     url = f"{base_url}/tools/{tool}"
     try:
         response = requests.post(url, json={"arguments": kwargs}, timeout=30)
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
         logger.error("Request to %s failed: %s", url, e)
         return f"❌ Request failed: {e}"
 

--- a/core/mcp_tools.py
+++ b/core/mcp_tools.py
@@ -1,0 +1,43 @@
+import json
+import logging
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Default MCP server endpoints
+MCP_SERVER_URLS: Dict[str, str] = {
+    "filesystem": "http://localhost:8001",
+    "web_fetch": "http://localhost:8002",
+    "git": "http://localhost:8003",
+    "image_analysis": "http://localhost:8004",
+}
+
+
+def call_tool(server: str, tool: str, **kwargs: Any) -> str:
+    """Call an MCP tool and return the result as a string."""
+    base_url = MCP_SERVER_URLS.get(server)
+    if not base_url:
+        return f"Unknown MCP server: {server}"
+
+    url = f"{base_url}/tools/{tool}"
+    try:
+        response = requests.post(url, json={"arguments": kwargs}, timeout=30)
+    except Exception as e:
+        logger.error("Request to %s failed: %s", url, e)
+        return f"❌ Request failed: {e}"
+
+    if response.status_code != 200:
+        logger.error("MCP server error %s: %s", response.status_code, response.text)
+        return f"❌ {response.status_code}: {response.text}"
+
+    # Pretty print JSON if possible
+    content_type = response.headers.get("content-type", "")
+    if "application/json" in content_type:
+        try:
+            data = response.json()
+            return json.dumps(data, indent=2)
+        except Exception:
+            return response.text
+    return response.text

--- a/mcp_servers/README.md
+++ b/mcp_servers/README.md
@@ -183,6 +183,16 @@ response = httpx.post("http://localhost:8003/tools/git_status",
                      json={"arguments": {"repo_path": "/home/ant/AI/Project"}})
 ```
 
+### Using MCP Tools from Chat
+
+In the AI Studio chat box you can call these tools directly:
+
+```text
+/tool filesystem.read_file path=/tmp/foo.txt
+```
+
+The command format is `/tool <server>.<method> key=value`.
+
 ## Monitoring and Logging
 
 All servers include logging and can be monitored:


### PR DESCRIPTION
## Summary
- implement `core.mcp_tools` with helper for MCP server requests
- add `/tool` chat command handling in `core.ollama`
- document usage in README and MCP server README

## Testing
- `python -m py_compile core/ollama.py core/mcp_tools.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684ac14b9a94832890824cc6e4300025