### PR TITLE
Make paths configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ curl -X POST http://localhost:8000/analyze-image \
 
 ### config.yaml
 ```yaml
-sd_model: "/home/ant/AI/illustrious-ai-studio/models/Illustrious.safetensors"
+sd_model: "models/Illustrious.safetensors"
 ollama_model: "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"
 ollama_vision_model: "qwen2.5vl:7b"
 ollama_base_url: "http://localhost:11434"
@@ -254,6 +254,7 @@ generation_defaults:
   width: 1024
   height: 1024
 ```
+Model paths can also be set via environment variables, e.g. `SD_MODEL` for the SDXL model or `MCP_CONFIG` for MCP servers.
 
 ## 🎯 Performance Tips
 

--- a/SETUP_COMPLETE.md
+++ b/SETUP_COMPLETE.md
@@ -6,7 +6,7 @@ Your AI Studio is now fully configured and tested with all features working corr
 
 ### 1. **Image Generation (SDXL)**
 - Model: Illustrious.safetensors (6.5GB)
-- Location: `/home/ant/AI/illustrious-ai-studio/models/`
+- Location: `models/`
 - Status: ✅ Working perfectly
 
 ### 2. **LLM Text Generation**

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # Illustrious AI Studio Configuration
 # Model Paths - Update these paths to match your model locations
-sd_model: "/home/ant/AI/illustrious-ai-studio/models/Illustrious.safetensors"  # Path to SDXL .safetensors model file
+sd_model: "models/Illustrious.safetensors"  # Path to SDXL .safetensors model file
 ollama_model: "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"  # Ollama model name for text generation
 ollama_vision_model: "qwen2.5vl:7b"  # Vision-language model for image analysis and Q&A
 ollama_base_url: "http://localhost:11434"  # Ollama API endpoint (default local installation)

--- a/core/config.py
+++ b/core/config.py
@@ -3,10 +3,12 @@ import os
 from pathlib import Path
 import yaml
 
+MODEL_DIR = Path(os.getenv("MODELS_DIR", "models"))
+
 
 @dataclass
 class AppConfig:
-    sd_model: str = "/home/ant/AI/Project/SDXL Models/waiNSFWIllustrious_v140.safetensors"
+    sd_model: str = str(MODEL_DIR / "Illustrious.safetensors")
     ollama_model: str = "goekdenizguelmez/JOSIEFIED-Qwen3:8b-q6_k"
     ollama_vision_model: str = "qwen2.5vl:7b"
     ollama_base_url: str = "http://localhost:11434"

--- a/mcp_servers/README.md
+++ b/mcp_servers/README.md
@@ -80,8 +80,8 @@ MCP servers are configured in `config.json`:
 {
   "mcpServers": {
     "filesystem": {
-      "command": "/home/ant/miniconda3/bin/python",
-      "args": ["/home/ant/AI/Project/mcp_servers/filesystem_server.py"],
+      "command": "python",
+      "args": ["${MCP_DIR}/filesystem_server.py"],
       "description": "Secure filesystem operations",
       "port": 8001,
       "enabled": true
@@ -98,10 +98,10 @@ The servers include security controls:
 {
   "settings": {
     "allowed_directories": [
-      "/home/ant/AI/Project",
+      "${WORKSPACE_DIR}",
       "/tmp/illustrious_ai",
-      "/home/ant/AI/Project/gallery",
-      "/home/ant/AI/Project/examples"
+      "${WORKSPACE_DIR}/gallery",
+      "${WORKSPACE_DIR}/examples"
     ]
   }
 }
@@ -112,7 +112,7 @@ The servers include security controls:
 ### Option 1: Start All Servers (Recommended)
 
 ```bash
-cd /home/ant/AI/Project/mcp_servers
+cd mcp_servers
 python start_all.py
 ```
 
@@ -121,7 +121,7 @@ This starts all enabled servers and monitors them.
 ### Option 2: Use the Manager
 
 ```bash
-cd /home/ant/AI/Project/mcp_servers
+cd mcp_servers
 
 # Start all servers
 python manager.py
@@ -142,7 +142,7 @@ python manager.py --restart filesystem
 ### Option 3: Start Individual Servers
 
 ```bash
-cd /home/ant/AI/Project/mcp_servers
+cd mcp_servers
 
 # Start filesystem server
 python filesystem_server.py
@@ -171,8 +171,8 @@ Once the MCP servers are running, they can be accessed:
 import httpx
 
 # Using filesystem server
-response = httpx.post("http://localhost:8001/tools/read_file", 
-                     json={"arguments": {"path": "/home/ant/AI/Project/README.md"}})
+response = httpx.post("http://localhost:8001/tools/read_file",
+                     json={"arguments": {"path": "${WORKSPACE_DIR}/README.md"}})
 
 # Using web fetch server
 response = httpx.post("http://localhost:8002/tools/fetch_url",
@@ -180,7 +180,7 @@ response = httpx.post("http://localhost:8002/tools/fetch_url",
 
 # Using git server
 response = httpx.post("http://localhost:8003/tools/git_status",
-                     json={"arguments": {"repo_path": "/home/ant/AI/Project"}})
+                     json={"arguments": {"repo_path": "${WORKSPACE_DIR}"}})
 ```
 
 ### Using MCP Tools from Chat

--- a/mcp_servers/config.json
+++ b/mcp_servers/config.json
@@ -1,29 +1,29 @@
 {
   "mcpServers": {
     "filesystem": {
-      "command": "/home/ant/miniconda3/bin/python",
-      "args": ["/home/ant/AI/Project/mcp_servers/filesystem_server.py"],
+      "command": "python",
+      "args": ["${MCP_DIR}/filesystem_server.py"],
       "description": "Secure filesystem operations with configurable access controls",
       "port": 8001,
       "enabled": true
     },
     "web-fetch": {
-      "command": "/home/ant/miniconda3/bin/python",
-      "args": ["/home/ant/AI/Project/mcp_servers/web_fetch_server.py"],
+      "command": "python",
+      "args": ["${MCP_DIR}/web_fetch_server.py"],
       "description": "Web content fetching and conversion for efficient LLM usage",
       "port": 8002,
       "enabled": true
     },
     "git": {
-      "command": "/home/ant/miniconda3/bin/python",
-      "args": ["/home/ant/AI/Project/mcp_servers/git_server.py"],
+      "command": "python",
+      "args": ["${MCP_DIR}/git_server.py"],
       "description": "Git repository operations and information",
       "port": 8003,
       "enabled": true
     },
     "image-analysis": {
-      "command": "/home/ant/miniconda3/bin/python",
-      "args": ["/home/ant/AI/Project/mcp_servers/image_analysis_server.py"],
+      "command": "python",
+      "args": ["${MCP_DIR}/image_analysis_server.py"],
       "description": "Image analysis capabilities for the AI Studio",
       "port": 8004,
       "enabled": true
@@ -34,10 +34,10 @@
     "auto_restart": true,
     "log_level": "INFO",
     "allowed_directories": [
-      "/home/ant/AI/Project",
+      "${WORKSPACE_DIR}",
       "/tmp/illustrious_ai",
-      "/home/ant/AI/Project/gallery",
-      "/home/ant/AI/Project/examples"
+      "${WORKSPACE_DIR}/gallery",
+      "${WORKSPACE_DIR}/examples"
     ]
   }
 }

--- a/mcp_servers/filesystem_server.py
+++ b/mcp_servers/filesystem_server.py
@@ -19,11 +19,12 @@ logger = logging.getLogger("filesystem-server")
 mcp = FastMCP("Filesystem Server")
 
 # Configuration
+BASE_DIR = Path(os.getenv("WORKSPACE_DIR", Path(__file__).resolve().parents[1]))
 ALLOWED_DIRECTORIES = [
-    "/home/ant/AI/Project",
+    str(BASE_DIR),
     "/tmp/illustrious_ai",
-    "/home/ant/AI/Project/gallery",
-    "/home/ant/AI/Project/examples",
+    str(BASE_DIR / "gallery"),
+    str(BASE_DIR / "examples"),
 ]
 
 def is_path_allowed(path: Path) -> bool:

--- a/mcp_servers/git_server.py
+++ b/mcp_servers/git_server.py
@@ -20,8 +20,9 @@ logger = logging.getLogger("git-server")
 mcp = FastMCP("Git Server")
 
 # Configuration
+BASE_DIR = Path(os.getenv("WORKSPACE_DIR", Path(__file__).resolve().parents[1]))
 ALLOWED_REPOSITORIES = [
-    "/home/ant/AI/Project",
+    str(BASE_DIR),
 ]
 
 def is_repo_allowed(repo_path: Path) -> bool:
@@ -71,7 +72,7 @@ def run_git_command(repo_path: str, command: List[str]) -> Dict[str, Any]:
         raise Exception(f"Error running git command: {str(e)}")
 
 @mcp.tool()
-def git_status(repo_path: str = "/home/ant/AI/Project") -> Dict[str, Any]:
+def git_status(repo_path: str = str(BASE_DIR)) -> Dict[str, Any]:
     """
     Get the status of a Git repository.
     
@@ -120,7 +121,7 @@ def git_status(repo_path: str = "/home/ant/AI/Project") -> Dict[str, Any]:
     }
 
 @mcp.tool()
-def git_log(repo_path: str = "/home/ant/AI/Project", max_count: int = 10) -> List[Dict[str, Any]]:
+def git_log(repo_path: str = str(BASE_DIR), max_count: int = 10) -> List[Dict[str, Any]]:
     """
     Get the commit history of a Git repository.
     
@@ -157,7 +158,7 @@ def git_log(repo_path: str = "/home/ant/AI/Project", max_count: int = 10) -> Lis
     return commits
 
 @mcp.tool()
-def git_diff(repo_path: str = "/home/ant/AI/Project", filename: Optional[str] = None, staged: bool = False) -> str:
+def git_diff(repo_path: str = str(BASE_DIR), filename: Optional[str] = None, staged: bool = False) -> str:
     """
     Get the diff of changes in a Git repository.
     
@@ -183,7 +184,7 @@ def git_diff(repo_path: str = "/home/ant/AI/Project", filename: Optional[str] = 
     return result["stdout"]
 
 @mcp.tool()
-def git_branch_list(repo_path: str = "/home/ant/AI/Project") -> List[Dict[str, Any]]:
+def git_branch_list(repo_path: str = str(BASE_DIR)) -> List[Dict[str, Any]]:
     """
     List all branches in a Git repository.
     
@@ -218,7 +219,7 @@ def git_branch_list(repo_path: str = "/home/ant/AI/Project") -> List[Dict[str, A
     return branches
 
 @mcp.tool()
-def git_show_commit(repo_path: str = "/home/ant/AI/Project", commit_hash: str = "HEAD") -> Dict[str, Any]:
+def git_show_commit(repo_path: str = str(BASE_DIR), commit_hash: str = "HEAD") -> Dict[str, Any]:
     """
     Show detailed information about a specific commit.
     
@@ -269,7 +270,7 @@ def git_show_commit(repo_path: str = "/home/ant/AI/Project", commit_hash: str = 
     return commit_info
 
 @mcp.tool()
-def git_remote_info(repo_path: str = "/home/ant/AI/Project") -> List[Dict[str, str]]:
+def git_remote_info(repo_path: str = str(BASE_DIR)) -> List[Dict[str, str]]:
     """
     Get information about remote repositories.
     
@@ -298,7 +299,7 @@ def git_remote_info(repo_path: str = "/home/ant/AI/Project") -> List[Dict[str, s
     return remotes
 
 @mcp.tool()
-def git_file_history(repo_path: str = "/home/ant/AI/Project", filename: str, max_count: int = 10) -> List[Dict[str, Any]]:
+def git_file_history(repo_path: str = str(BASE_DIR), filename: str, max_count: int = 10) -> List[Dict[str, Any]]:
     """
     Get the commit history for a specific file.
     

--- a/mcp_servers/image_analysis_server.py
+++ b/mcp_servers/image_analysis_server.py
@@ -23,10 +23,11 @@ logger = logging.getLogger("image-analysis-server")
 mcp = FastMCP("Image Analysis Server")
 
 # Configuration
+BASE_DIR = Path(os.getenv("WORKSPACE_DIR", Path(__file__).resolve().parents[1]))
 ALLOWED_DIRECTORIES = [
-    "/home/ant/AI/Project/gallery",
+    str(BASE_DIR / "gallery"),
     "/tmp/illustrious_ai/gallery",
-    "/home/ant/AI/Project/examples",
+    str(BASE_DIR / "examples"),
 ]
 
 def is_path_allowed(path: Path) -> bool:

--- a/mcp_servers/start_all.py
+++ b/mcp_servers/start_all.py
@@ -7,8 +7,9 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+import os
 
-def start_server(script_path: str, port: int) -> subprocess.Popen:
+def start_server(script_path: Path | str, port: int) -> subprocess.Popen:
     """Start a single MCP server."""
     env = {
         'MCP_SERVER_PORT': str(port),
@@ -16,7 +17,7 @@ def start_server(script_path: str, port: int) -> subprocess.Popen:
     }
     
     return subprocess.Popen(
-        [sys.executable, script_path],
+        [sys.executable, str(script_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env
@@ -24,11 +25,12 @@ def start_server(script_path: str, port: int) -> subprocess.Popen:
 
 def main():
     """Start all MCP servers."""
+    base = Path(os.getenv('MCP_DIR', Path(__file__).parent))
     servers = {
-        'filesystem': ('/home/ant/AI/Project/mcp_servers/filesystem_server.py', 8001),
-        'web-fetch': ('/home/ant/AI/Project/mcp_servers/web_fetch_server.py', 8002),
-        'git': ('/home/ant/AI/Project/mcp_servers/git_server.py', 8003),
-        'image-analysis': ('/home/ant/AI/Project/mcp_servers/image_analysis_server.py', 8004),
+        'filesystem': (base / 'filesystem_server.py', 8001),
+        'web-fetch': (base / 'web_fetch_server.py', 8002),
+        'git': (base / 'git_server.py', 8003),
+        'image-analysis': (base / 'image_analysis_server.py', 8004),
     }
     
     processes = {}

--- a/setup_models.py
+++ b/setup_models.py
@@ -114,7 +114,7 @@ def update_config(config_path: Path) -> bool:
             config = {}
         
         # Update model paths
-        model_path = str((MODELS_DIR / RECOMMENDED_MODELS["sdxl"]["filename"]).absolute())
+        model_path = str(MODELS_DIR / RECOMMENDED_MODELS["sdxl"]["filename"])
         config['sd_model'] = model_path
         config['ollama_model'] = OLLAMA_MODELS["llm"]
         config['ollama_vision_model'] = OLLAMA_MODELS["vision"]


### PR DESCRIPTION
## Summary
- replace absolute model path with relative path in `config.yaml`
- derive model directory from `MODELS_DIR` env variable
- use env vars in `mcp_servers/config.json`
- let MCP server manager load config from env variable and expand env vars
- make start_all.py and MCP servers refer to workspace directory env var
- update setup script and docs accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL and yaml)*

------
https://chatgpt.com/codex/tasks/task_e_684ac3ef4dc08328afec2366e3d8f448