### PR TITLE
Add selective model loader UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ python main.py --lazy-load
 ```
 Then open: http://localhost:7860
 
+Use the **Model Loader** section on the System Info tab to load SDXL or Ollama
+models on demand if you started with `--lazy-load`.
+
 ### Memory Management
 ```bash
 # For image generation heavy workloads
@@ -177,7 +180,9 @@ pytest
 - Model configuration and status
 - Switch models on the fly
 - View API documentation
-- **Load Models On Demand** buttons for SDXL and Ollama
+ - **Load Models On Demand**: Use the *Model Loader* checkboxes to select SDXL,
+   the Ollama text model, and/or the vision model, then click **Load Selected**
+   to initialize them
 
 ## 🔧 API Usage
 

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -1,0 +1,74 @@
+import types
+
+
+def test_model_loader_button(monkeypatch):
+    events = {}
+    import os, sys
+    if os.getcwd() not in sys.path:
+        sys.path.insert(0, os.getcwd())
+    import ui.web as web
+    from core.state import AppState
+
+    class DummyComp:
+        def __init__(self, *a, label=None, **k):
+            self.label = label or (a[0] if a else None)
+        def __call__(self, *a, **k):
+            return self
+        def click(self, fn=None, inputs=None, outputs=None):
+            if self.label == "⚡ Load Selected":
+                events['fn'] = fn
+            return self
+        def change(self, *a, **k):
+            return self
+        def submit(self, *a, **k):
+            return self
+        def then(self, *a, **k):
+            return self
+        def load(self, *a, **k):
+            return self
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc_val, tb):
+            pass
+
+    class DummyBlocks(DummyComp):
+        def Row(self, *a, **k):
+            return self
+        def Column(self, *a, **k):
+            return self
+        def Tab(self, *a, **k):
+            return self
+        def Accordion(self, *a, **k):
+            return self
+        def Group(self, *a, **k):
+            return self
+
+    class DummyModule(types.ModuleType):
+        def __getattr__(self, name):
+            if name in ["Blocks", "Row", "Column", "Tab", "Accordion", "Group"]:
+                return DummyBlocks
+            if name in ["Button", "DownloadButton", "Checkbox", "Textbox", "Slider", "Dropdown", "Image", "Chatbot", "File", "JSON", "Code"]:
+                return DummyComp
+            if name == "Markdown":
+                return lambda *a, **k: None
+            if name == "themes":
+                return types.SimpleNamespace(Base=lambda *a, **k: None)
+            if name == "update":
+                return lambda *a, **k: None
+            return DummyComp
+
+    dummy_gr = DummyModule('gr')
+    monkeypatch.setattr(web, 'gr', dummy_gr)
+
+    calls = {"sdxl": 0, "ollama": 0}
+    monkeypatch.setattr(web.sdxl, 'init_sdxl', lambda st: calls.__setitem__('sdxl', calls['sdxl'] + 1))
+    monkeypatch.setattr(web.ollama, 'init_ollama', lambda st: calls.__setitem__('ollama', calls['ollama'] + 1))
+    monkeypatch.setattr(web, 'get_model_status', lambda st: 'ok')
+
+    state = AppState()
+    web.create_gradio_app(state)
+    fn = events.get('fn')
+    assert fn is not None
+    fn(True, False, True)
+    assert calls["sdxl"] == 1
+    assert calls["ollama"] == 1


### PR DESCRIPTION
## Summary
- add a model loader section with checkboxes for SDXL and Ollama models
- refresh status after loading selected models
- document selective loading in README
- test that the model loader button triggers the correct init functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac7d6e834832892a66ef9ec9b51df