### PR TITLE
Remove default logging config from memory

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -5,7 +5,6 @@ import torch
 from .state import AppState
 from .config import CONFIG
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- avoid calling `logging.basicConfig` in `core/memory.py`
- rely on existing logger configuration

## Testing
- `pip install Pillow PyYAML httpx -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684ade6097a88328a9a1b8fa2e301041