### PR TITLE
Add chat history persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
 - **Smart Resolution Selector**: 7 optimized resolution presets with quality indicators
 - **Automatic Gallery**: Generated images saved with metadata
 - **Prompt Enhancement**: LLM improves your image prompts
-- **Session Management**: Persistent chat history
+- **Session Management**: Chat history automatically saved under your system's
+  temporary directory and reloaded at startup
 - **Model Switching**: Change models without restarting
 - **Improved Error Handling**: Better recovery from generation failures
 
@@ -188,7 +189,7 @@ pytest
 - Chat with the LLM
 - Use `#generate <description>` to create images
 - Call MCP tools with `/tool <server>.<method> key=value`
-- Maintains conversation history
+- Maintains conversation history across restarts
 
 ### 🔍 Image Analysis Tab
 - Upload any image for AI analysis

--- a/core/ollama.py
+++ b/core/ollama.py
@@ -1,17 +1,47 @@
 import base64
 import io
+import json
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from PIL import Image
 import requests
 
 from .state import AppState
-from .sdxl import generate_image, save_to_gallery
+from .sdxl import generate_image, save_to_gallery, TEMP_DIR
 from .config import CONFIG
 from .mcp_tools import call_tool
 
 logger = logging.getLogger(__name__)
+
+CHAT_HISTORY_FILE = Path(TEMP_DIR) / "chat_history.json"
+
+
+def load_chat_history(state: AppState) -> None:
+    """Load chat history from disk into the application state."""
+    try:
+        if CHAT_HISTORY_FILE.exists():
+            with open(CHAT_HISTORY_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for session_id, history in data.items():
+                state.chat_history_store[session_id] = [tuple(msg) for msg in history]
+    except Exception as e:
+        logger.error("Failed to load chat history: %s", e)
+
+
+def save_chat_history(state: AppState) -> None:
+    """Persist chat history from the application state to disk."""
+    try:
+        CHAT_HISTORY_FILE.parent.mkdir(exist_ok=True)
+        serializable = {
+            sid: [list(msg) for msg in history]
+            for sid, history in state.chat_history_store.items()
+        }
+        with open(CHAT_HISTORY_FILE, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error("Failed to save chat history: %s", e)
 
 
 
@@ -47,6 +77,7 @@ def init_ollama(state: AppState) -> Optional[str]:
             state.model_status["ollama"] = True
             state.ollama_model = target_model
             logger.info("Ollama text model '%s' loaded", target_model)
+            load_chat_history(state)
             
             # Initialize vision model if configured
             vision_model = getattr(CONFIG, 'ollama_vision_model', None)
@@ -76,6 +107,7 @@ def switch_ollama_model(state: AppState, name: str) -> bool:
     state.model_status["ollama"] = False
     state.model_status["multimodal"] = False
     state.chat_history_store.clear()
+    save_chat_history(state)
     CONFIG.ollama_model = name
     logger.info("Switching Ollama model to %s", name)
     return init_ollama(state) is not None
@@ -178,6 +210,7 @@ def handle_chat(state: AppState, message: str, session_id: str = "default", chat
             if len(parts) > 1:
                 response = parts[-1].strip()
     state.chat_history_store[session_id].append((message, response))
+    save_chat_history(state)
     if chat_history is None:
         chat_history = []
     chat_history.append([message, response])

--- a/core/ollama.py
+++ b/core/ollama.py
@@ -33,7 +33,7 @@ def load_chat_history(state: AppState) -> None:
 def save_chat_history(state: AppState) -> None:
     """Persist chat history from the application state to disk."""
     try:
-        CHAT_HISTORY_FILE.parent.mkdir(exist_ok=True)
+        CHAT_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
         serializable = {
             sid: [list(msg) for msg in history]
             for sid, history in state.chat_history_store.items()

--- a/tests/test_chat_history_persistence.py
+++ b/tests/test_chat_history_persistence.py
@@ -1,0 +1,37 @@
+import json
+import sys
+import os
+
+import pytest
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+
+
+def test_history_saved_and_loaded(tmp_path, monkeypatch):
+    from core.state import AppState
+    import core.ollama as ollama
+
+    state = AppState()
+    hist_file = tmp_path / "history.json"
+    monkeypatch.setattr(ollama, "CHAT_HISTORY_FILE", hist_file)
+    monkeypatch.setattr(ollama, "chat_completion", lambda *a, **k: "ai")
+
+    # Should load nothing
+    ollama.load_chat_history(state)
+    assert state.chat_history_store == {}
+
+    history, _ = ollama.handle_chat(state, "hi", session_id="s1", chat_history=[])
+    assert history == [["hi", "ai"]]
+
+    # File written
+    data = json.loads(hist_file.read_text())
+    assert data["s1"] == [["hi", "ai"]]
+
+    # Load into new state
+    new_state = AppState()
+    monkeypatch.setattr(ollama, "CHAT_HISTORY_FILE", hist_file)
+    ollama.load_chat_history(new_state)
+    assert new_state.chat_history_store["s1"] == [("hi", "ai")]
+


### PR DESCRIPTION
## Summary
- persist chat history to TEMP_DIR/chat_history.json
- load history on Ollama startup and save after each message
- add tests for chat history persistence
- document new behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b86b9dd988328a8b89e137bfdaedd