### PR TITLE
Support nested memory config

### DIFF
--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -92,7 +92,36 @@ class MemoryGuardian:
         }
         
         # Load from CONFIG if available
-        memory_config = getattr(CONFIG, 'memory_guardian', {})
+        memory_config = getattr(CONFIG, 'memory_guardian', {}) or {}
+
+        # Update threshold values if provided
+        thresholds_cfg = memory_config.get("thresholds", {}) or {}
+
+        def _percent(val: float) -> float:
+            val = float(val)
+            return val / 100.0 if val > 1 else val
+
+        if "low" in thresholds_cfg:
+            self.thresholds.low_threshold = _percent(thresholds_cfg["low"])
+        if "medium" in thresholds_cfg:
+            self.thresholds.medium_threshold = _percent(thresholds_cfg["medium"])
+        if "high" in thresholds_cfg:
+            self.thresholds.high_threshold = _percent(thresholds_cfg["high"])
+        if "critical" in thresholds_cfg:
+            self.thresholds.critical_threshold = _percent(thresholds_cfg["critical"])
+
+        safety_cfg = memory_config.get("safety_margins", {}) or {}
+        if "generation_reserve" in safety_cfg:
+            self.thresholds.generation_reserve_gb = float(safety_cfg["generation_reserve"])
+        if "llm_reserve" in safety_cfg:
+            self.thresholds.llm_reserve_gb = float(safety_cfg["llm_reserve"])
+
+        monitor_cfg = memory_config.get("monitoring", {}) or {}
+        if "normal_interval" in monitor_cfg:
+            self.thresholds.monitoring_interval = float(monitor_cfg["normal_interval"])
+        if "aggressive_interval" in monitor_cfg:
+            self.thresholds.aggressive_interval = float(monitor_cfg["aggressive_interval"])
+
         return {**default_config, **memory_config}
     
     def _register_default_interventions(self):

--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -92,7 +92,7 @@ class MemoryGuardian:
         }
         
         # Load from CONFIG if available
-        memory_config = getattr(CONFIG, 'memory_guardian', {}) or {}
+        memory_config = getattr(CONFIG, 'memory_guardian', {})
 
         # Update threshold values if provided
         thresholds_cfg = memory_config.get("thresholds", {}) or {}

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+from core.config import CONFIG
+
+
+def test_config_overrides(monkeypatch):
+    custom = {
+        "thresholds": {"low": 60, "medium": 80},
+        "safety_margins": {"generation_reserve": 1.0},
+        "monitoring": {"normal_interval": 3.0, "aggressive_interval": 1.0},
+    }
+    monkeypatch.setattr(CONFIG, "memory_guardian", custom, raising=False)
+    from core.state import AppState
+    from core.memory_guardian import MemoryGuardian
+    guardian = MemoryGuardian(AppState())
+    th = guardian.thresholds
+    assert th.low_threshold == 0.60
+    assert th.medium_threshold == 0.80
+    assert th.high_threshold == 0.95
+    assert th.critical_threshold == 0.98
+    assert th.generation_reserve_gb == 1.0
+    assert th.llm_reserve_gb == 1.5
+    assert th.monitoring_interval == 3.0
+    assert th.aggressive_interval == 1.0
+
+
+def test_defaults_preserved(monkeypatch):
+    partial = {
+        "thresholds": {"high": 90},
+        "monitoring": {"aggressive_interval": 0.3},
+    }
+    monkeypatch.setattr(CONFIG, "memory_guardian", partial, raising=False)
+    from core.state import AppState
+    from core.memory_guardian import MemoryGuardian
+    guardian = MemoryGuardian(AppState())
+    th = guardian.thresholds
+    assert th.low_threshold == 0.70
+    assert th.medium_threshold == 0.85
+    assert th.high_threshold == 0.90
+    assert th.critical_threshold == 0.98
+    assert th.monitoring_interval == 2.0
+    assert th.aggressive_interval == 0.3


### PR DESCRIPTION
## Summary
- extend `_load_memory_config` to read nested config sections
- add tests for overriding memory guardian config

## Testing
- `pytest tests/test_memory_config.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b884a6a1483289b87ca16af73b150