### PR TITLE
Add theme toggle and persistence

### DIFF
--- a/ui/custom.css
+++ b/ui/custom.css
@@ -7,6 +7,14 @@
     --text-color: #2c3e50;
     --accent-color: #27ae60;
 }
+:root.dark {
+    --primary-color: #d35400;
+    --secondary-color: #8e44ad;
+    --background-color: #1e1e1e;
+    --canvas-color: #2c2c2c;
+    --text-color: #f0f0f0;
+    --accent-color: #27ae60;
+}
 
 /* Main container styling */
 .main-container {

--- a/ui/web.py
+++ b/ui/web.py
@@ -32,7 +32,7 @@ def create_gradio_app(state: AppState):
 
     def save_theme_pref(choice: str):
         try:
-            TEMP_DIR.mkdir(exist_ok=True)
+            TEMP_DIR.mkdir(parents=True, exist_ok=True)
             with open(THEME_PREF_FILE, "w", encoding="utf-8") as f:
                 json.dump({"theme": choice}, f)
         except Exception as e:

--- a/ui/web.py
+++ b/ui/web.py
@@ -15,12 +15,11 @@ from core.prompt_templates import template_manager
 
 logger = logging.getLogger(__name__)
 
+THEME_PREF_FILE = TEMP_DIR / "theme_pref.json"
+
 def create_gradio_app(state: AppState):
     """Build and return the Gradio UI for the application."""
     css_file = (Path(__file__).parent / "custom.css").read_text()
-
-    THEME_PREF_FILE = TEMP_DIR / "theme_pref.json"
-
     def load_theme_pref():
         try:
             if THEME_PREF_FILE.exists():

--- a/ui/web.py
+++ b/ui/web.py
@@ -648,6 +648,7 @@ def create_gradio_app(state: AppState):
         theme_selector.change(
             fn=lambda m: save_theme_pref(m.lower()),
             inputs=theme_selector,
+            outputs=[],
             js="(mode) => { if(mode === 'Dark'){ document.documentElement.classList.add('dark'); } else { document.documentElement.classList.remove('dark'); } }"
         )
         enhance_btn.click(fn=lambda p: generate_prompt(state, p), inputs=prompt, outputs=prompt)


### PR DESCRIPTION
## Summary
- add user theme preference saved to TEMP_DIR
- apply saved light/dark mode on page load
- expose a radio selector to change theme
- support dark CSS variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b90c679008328a51790dcfc06f285