### PR TITLE
Add memory report endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ curl -X POST http://localhost:8000/analyze-image \
   }'
 ```
 
+### Memory Report
+```bash
+curl http://localhost:8000/memory-report
+```
+
 ## ⚙️ Configuration
 
 ### config.yaml

--- a/examples/API_DOCUMENTATION.md
+++ b/examples/API_DOCUMENTATION.md
@@ -278,6 +278,19 @@ if response.status_code == 200:
 
 ---
 
+## 🛡️ Memory Report
+
+### `GET /memory-report`
+
+Retrieve a detailed memory usage report from the Memory Guardian.
+
+**Example:**
+```bash
+curl http://localhost:8000/memory-report
+```
+
+---
+
 ## ⚠️ Error Handling ✨ **ENHANCED**
 
 ### Error Response Format

--- a/server/api.py
+++ b/server/api.py
@@ -11,6 +11,7 @@ from core.sdxl import generate_image
 from core.ollama import chat_completion, analyze_image
 from core.state import AppState
 from core.config import CONFIG
+from core.memory_guardian import get_memory_guardian
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,11 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
         if request.ollama_model:
             result["ollama"] = ollama.switch_ollama_model(state, request.ollama_model)
         return {"models": state.model_status, **result}
+
+    @app.get("/memory-report")
+    async def memory_report(state: AppState = Depends(get_state)):
+        guardian = get_memory_guardian(state)
+        return guardian.get_memory_report()
 
     return app
 


### PR DESCRIPTION
## Summary
- expose memory report from Memory Guardian via `/memory-report`
- document usage in README and API docs

## Testing
- `pip install Pillow PyYAML httpx psutil -q`
- `pytest -q` *(fails: Client.__init__() got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684b95ec533883289a2890bc9d991b76