### PR TITLE
Add gallery directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ generation_defaults:
   guidance_scale: 7.5
   width: 1024
   height: 1024
+gallery_dir: "/tmp/illustrious_ai/gallery"
 ```
-Model paths can also be set via environment variables, e.g. `SD_MODEL` for the SDXL model or `MCP_CONFIG` for MCP servers.
+Model paths can also be set via environment variables, e.g. `SD_MODEL` for the SDXL model or `MCP_CONFIG` for MCP servers. Use `GALLERY_DIR` to customize where generated images are saved.
 
 ## 🎯 Performance Tips
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,9 @@ generation_defaults:
   guidance_scale: 7.5
   width: 512
   height: 512
-  batch_size: 1
+batch_size: 1
 conda_env: illustrious
+gallery_dir: /tmp/illustrious_ai/gallery
 
 # Memory Guardian Configuration
 memory_guardian:

--- a/core/config.py
+++ b/core/config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, fields, asdict
 import os
 from pathlib import Path
+import tempfile
 import yaml
 
 MODEL_DIR = Path(os.getenv("MODELS_DIR", "models"))
@@ -18,6 +19,9 @@ class AppConfig:
     generation_defaults: dict | None = None
     gpu_backend: str = "cuda"
     load_models_on_startup: bool = True
+
+    # Gallery directory for generated images
+    gallery_dir: str = str(Path(tempfile.gettempdir()) / "illustrious_ai" / "gallery")
     
     # Memory Guardian settings
     memory_guardian: dict | None = None
@@ -58,6 +62,7 @@ def load_config(path: str | None = None) -> AppConfig:
     config.ollama_model = os.getenv("OLLAMA_MODEL", config.ollama_model)
     config.ollama_base_url = os.getenv("OLLAMA_BASE_URL", config.ollama_base_url)
     config.gpu_backend = os.getenv("GPU_BACKEND", config.gpu_backend)
+    config.gallery_dir = os.getenv("GALLERY_DIR", config.gallery_dir)
     env_lazy = os.getenv("LOAD_MODELS_ON_STARTUP")
     if env_lazy is not None:
         config.load_models_on_startup = env_lazy.lower() not in ("false", "0", "no")

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 TEMP_DIR = Path(tempfile.gettempdir()) / "illustrious_ai"
 TEMP_DIR.mkdir(exist_ok=True)
-GALLERY_DIR = TEMP_DIR / "gallery"
-GALLERY_DIR.mkdir(exist_ok=True)
+GALLERY_DIR = Path(CONFIG.gallery_dir)
+GALLERY_DIR.mkdir(parents=True, exist_ok=True)
 
 
 

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 TEMP_DIR = Path(tempfile.gettempdir()) / "illustrious_ai"
 TEMP_DIR.mkdir(exist_ok=True)
 GALLERY_DIR = Path(CONFIG.gallery_dir)
-GALLERY_DIR.mkdir(parents=True, exist_ok=True)
 
 
 

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -15,10 +15,12 @@ def test_load_config_file_and_env(tmp_path, monkeypatch):
         "sd_model: '/tmp/model.pt'\nollama_model: 'test-model'\nollama_base_url: 'http://example.com'"
     )
     monkeypatch.setenv("SD_MODEL", "/env/model.pt")
+    monkeypatch.setenv("GALLERY_DIR", "/tmp/gallery_env")
     conf = config.load_config(str(cfg))
     assert conf.sd_model == "/env/model.pt"
     assert conf.ollama_model == "test-model"
     assert conf.ollama_base_url == "http://example.com"
+    assert conf.gallery_dir == "/tmp/gallery_env"
 
 
 def test_init_sdxl_missing_model(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow specifying a gallery directory in `AppConfig`
- honour `GALLERY_DIR` env var
- derive SDXL gallery path from configuration
- document gallery path option in README and config
- test config load with the new field

## Testing
- `pytest tests/test_config_and_init.py tests/test_memory_config.py -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684b99bcfe0083289ee8927389ab7910