### PR TITLE
Fix memory guardian cleanup

### DIFF
--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -453,3 +453,4 @@ def stop_memory_guardian():
     global _memory_guardian
     if _memory_guardian:
         _memory_guardian.stop_monitoring()
+        _memory_guardian = None

--- a/tests/test_memory_guardian_lifecycle.py
+++ b/tests/test_memory_guardian_lifecycle.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+def test_guardian_recreated_after_stop():
+    from core.state import AppState
+    from core.memory_guardian import start_memory_guardian, stop_memory_guardian
+    from core.memory_guardian import get_memory_guardian
+
+    app_state = AppState()
+    guardian1 = start_memory_guardian(app_state)
+    stop_memory_guardian()
+    guardian2 = start_memory_guardian(app_state)
+    assert guardian1 is not guardian2
+    # ensure global instance matches returned guardian2
+    assert get_memory_guardian() is guardian2
+    stop_memory_guardian()


### PR DESCRIPTION
## Summary
- ensure `_memory_guardian` is cleared when stopping monitoring
- add lifecycle test verifying a new guardian instance is created after restarting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9d853f9083289c54804a7ffbfacb