### PR TITLE
Sync config defaults with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ generation_defaults:
   height: 1024
 gallery_dir: "/tmp/illustrious_ai/gallery"
 ```
+These defaults are optimized for GPUs with **16GB or more VRAM**. If you have a lower-memory card (8–12GB), reduce `width`, `height`, and `steps` in your `config.yaml` – for example `512x512` at 15 steps.
+
 Model paths can also be set via environment variables, e.g. `SD_MODEL` for the SDXL model or `MCP_CONFIG` for MCP servers. Use `GALLERY_DIR` to customize where generated images are saved.
 
 ## 🎯 Performance Tips

--- a/config.yaml
+++ b/config.yaml
@@ -10,10 +10,10 @@ cuda_settings:
   enable_tf32: true
   memory_fraction: 0.95
 generation_defaults:
-  steps: 15
+  steps: 30
   guidance_scale: 7.5
-  width: 512
-  height: 512
+  width: 1024
+  height: 1024
 batch_size: 1
 conda_env: illustrious
 gallery_dir: /tmp/illustrious_ai/gallery


### PR DESCRIPTION
## Summary
- bring `config.yaml` defaults in line with README values
- document that these defaults assume a 16GB+ GPU and suggest reduced values for lower VRAM cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684ba25e7e508328b04d0eea54e5297a