### PR TITLE
Fix heading formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
 
 ## 🆕 Latest Improvements
 
--### 🚀 **Automated Setup & Model Management**
+### 🚀 **Automated Setup & Model Management**
 - **One-Command Setup**: `python setup.py` handles everything
 - **Automatic Downloads**: Recommended models downloaded and configured
 - **Smart Configuration**: Auto-updating config.yaml with optimal settings


### PR DESCRIPTION
## Summary
- correct malformed heading in README so it renders properly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_684ba34b21c083289b6de0eee1c06e7c