### PR TITLE
Fix memory stats helper

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -41,3 +41,8 @@ def get_memory_stats_markdown(state: AppState) -> str:
     text += f"• RAM: {stats.system_ram_usage_percent:.1f}% used\n"
     text += f"• Pressure: {stats.pressure_level.value}"
     return text
+
+
+def get_memory_stats_wrapper(state: AppState) -> str:
+    """Compatibility wrapper returning formatted memory statistics."""
+    return get_memory_stats_markdown(state)

--- a/ui/web.py
+++ b/ui/web.py
@@ -9,7 +9,7 @@ from core.sdxl import generate_image, TEMP_DIR, get_latest_image, init_sdxl, get
 from core.config import CONFIG
 from core.ollama import generate_prompt, handle_chat, analyze_image, init_ollama
 from core import sdxl, ollama
-from core.memory import get_model_status, get_memory_stats_markdown
+from core.memory import get_model_status, get_memory_stats_markdown, get_memory_stats_wrapper
 from core.state import AppState
 from core.prompt_templates import template_manager
 


### PR DESCRIPTION
## Summary
- add `get_memory_stats_wrapper` helper that calls existing markdown function
- import wrapper in the UI

## Testing
- `pytest -k memory_stats -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python main.py --quick-start --no-sdxl --no-ollama --web-port 7860` *(fails: ModuleNotFoundError: No module named 'gradio')*

------
https://chatgpt.com/codex/tasks/task_e_684ba9f6a8288328984e5e0092d6fe9f