### PR TITLE
Fix gallery directory creation

### DIFF
--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -56,7 +56,6 @@ def save_to_gallery(image: Image.Image, prompt: str, metadata: dict | None = Non
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{uuid.uuid4().hex[:8]}.png"
     filepath = GALLERY_DIR / filename
-    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
     image.save(filepath)
     metadata_file = filepath.with_suffix('.json')
     metadata_info = {

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -56,6 +56,7 @@ def save_to_gallery(image: Image.Image, prompt: str, metadata: dict | None = Non
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{uuid.uuid4().hex[:8]}.png"
     filepath = GALLERY_DIR / filename
+    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
     image.save(filepath)
     metadata_file = filepath.with_suffix('.json')
     metadata_info = {

--- a/tests/test_save_gallery.py
+++ b/tests/test_save_gallery.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+from PIL import Image
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+
+def test_save_to_gallery_creates_directory(tmp_path, monkeypatch):
+    from core import sdxl
+
+    gallery_dir = tmp_path / "gallery"
+    # Ensure directory does not exist beforehand
+    assert not gallery_dir.exists()
+
+    monkeypatch.setattr(sdxl, "GALLERY_DIR", gallery_dir)
+    monkeypatch.setattr(sdxl.CONFIG, "gallery_dir", str(gallery_dir))
+
+    img = Image.new("RGB", (10, 10), color="red")
+    saved_path = sdxl.save_to_gallery(img, "test prompt")
+
+    assert gallery_dir.exists()
+    assert os.path.exists(saved_path)
+    metadata_file = Path(saved_path).with_suffix('.json')
+    assert metadata_file.exists()

--- a/tests/test_save_gallery.py
+++ b/tests/test_save_gallery.py
@@ -15,7 +15,6 @@ def test_save_to_gallery_creates_directory(tmp_path, monkeypatch):
     assert not gallery_dir.exists()
 
     monkeypatch.setattr(sdxl, "GALLERY_DIR", gallery_dir)
-    monkeypatch.setattr(sdxl.CONFIG, "gallery_dir", str(gallery_dir))
 
     img = Image.new("RGB", (10, 10), color="red")
     saved_path = sdxl.save_to_gallery(img, "test prompt")


### PR DESCRIPTION
## Summary
- ensure SDXL gallery directory exists before saving images
- add unit test for saving when gallery directory is missing

## Testing
- `pytest tests/test_save_gallery.py -vv` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_684bab654dfc8328b1856afa36b857d7