### PR TITLE
Fix batch_size config loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ generation_defaults:
   guidance_scale: 7.5
   width: 1024
   height: 1024
+  batch_size: 1
 ```
 
 Environment variables override config:

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ generation_defaults:
   guidance_scale: 7.5
   width: 1024
   height: 1024
+  batch_size: 1
 gallery_dir: "/tmp/illustrious_ai/gallery"
 ```
 These defaults are optimized for GPUs with **16GB or more VRAM**. If you have a lower-memory card (8–12GB), reduce `width`, `height`, and `steps` in your `config.yaml` – for example `512x512` at 15 steps.

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ generation_defaults:
   guidance_scale: 7.5
   width: 1024
   height: 1024
-batch_size: 1
+  batch_size: 1
 conda_env: illustrious
 gallery_dir: /tmp/illustrious_ai/gallery
 

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -56,6 +56,7 @@ def save_to_gallery(image: Image.Image, prompt: str, metadata: dict | None = Non
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{uuid.uuid4().hex[:8]}.png"
     filepath = GALLERY_DIR / filename
+    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
     image.save(filepath)
     metadata_file = filepath.with_suffix('.json')
     metadata_info = {


### PR DESCRIPTION
## Summary
- move `batch_size` under `generation_defaults`
- mention `batch_size` in README and CLAUDE docs
- ensure `save_to_gallery` creates the gallery directory

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bae630bb8832881a72c4f28019135