### PR TITLE
Add memory guardian profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ python memory_manager.py --clear
 - **High (95%)**: Aggressive management (model unloading)
 - **Critical (98%)**: Emergency intervention (force unload all models)
 
+**Profiles:** configure `memory_guardian.profile` to quickly set these thresholds.
+- **Conservative** – early intervention (60/75/90/95)
+- **Balanced** – default thresholds (70/85/95/98)
+- **Aggressive** – waits longer before intervening (80/90/97/99)
+
 **Testing the System:**
 ```bash
 # Test the Memory Guardian functionality

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,8 @@ gallery_dir: /tmp/illustrious_ai/gallery
 # Memory Guardian Configuration
 memory_guardian:
   enabled: true
-  profile: balanced  # conservative, balanced, aggressive
+  # Threshold presets: conservative, balanced, or aggressive
+  profile: balanced
   auto_model_switching: true
   auto_resolution_scaling: true
   auto_batch_adjustment: true
@@ -29,7 +30,7 @@ memory_guardian:
   log_memory_stats: true
   intervention_cooldown: 5.0  # seconds between interventions
   
-  # Memory thresholds (as percentages)
+  # Thresholds (percentage). Defaults depend on the selected profile.
   thresholds:
     low: 70      # Start monitoring closely
     medium: 85   # Begin preventive actions

--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -94,6 +94,36 @@ class MemoryGuardian:
         # Load from CONFIG if available
         memory_config = getattr(CONFIG, 'memory_guardian', {})
 
+        # Apply threshold presets based on the selected profile
+        profile = memory_config.get("profile", default_config["profile"]).lower()
+        profile_thresholds = {
+            "conservative": {
+                "low": 0.60,
+                "medium": 0.75,
+                "high": 0.90,
+                "critical": 0.95,
+            },
+            "balanced": {
+                "low": 0.70,
+                "medium": 0.85,
+                "high": 0.95,
+                "critical": 0.98,
+            },
+            "aggressive": {
+                "low": 0.80,
+                "medium": 0.90,
+                "high": 0.97,
+                "critical": 0.99,
+            },
+        }
+
+        if profile in profile_thresholds:
+            th = profile_thresholds[profile]
+            self.thresholds.low_threshold = th["low"]
+            self.thresholds.medium_threshold = th["medium"]
+            self.thresholds.high_threshold = th["high"]
+            self.thresholds.critical_threshold = th["critical"]
+
         # Update threshold values if provided
         thresholds_cfg = memory_config.get("thresholds", {}) or {}
 


### PR DESCRIPTION
## Summary
- add profile-based threshold presets to `_load_memory_config`
- document new profiles in README
- note profiles in `config.yaml` comments

## Testing
- `pip install Pillow PyYAML`
- `pip install psutil`
- `pytest tests/test_memory_config.py -q`
- `pytest tests/test_prompt_templates.py -q`
- `pytest tests/test_memory_guardian_lifecycle.py -q`
- `python test_simple.py` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bb1f49b18832895c30a1a40248993