### PR TITLE
Add gallery tab for browsing saved images

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
 - **Quick Style Buttons**: One-click application of popular styles (Anime, Realistic, Artistic, Fantasy, Cyberpunk)
 - **Smart Resolution Selector**: 7 optimized resolution presets with quality indicators
 - **Automatic Gallery**: Generated images saved with metadata
+- **Gallery Viewer Tab**: Browse saved images and metadata
 - **Prompt Enhancement**: LLM improves your image prompts
 - **Session Management**: Chat history automatically saved under your system's
   temporary directory and reloaded at startup
@@ -195,6 +196,10 @@ pytest
 - Upload any image for AI analysis
 - Ask specific questions about images
 - Works with generated images too
+
+### 🖼️ Gallery Tab ✨ **NEW**
+- Browse saved images in a gallery view
+- View metadata, open files, or copy their paths
 
 ### 📝 Prompt Templates Tab ✨ **NEW**
 - **Save Templates**: Save your best prompts for reuse

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -56,7 +56,7 @@ def save_to_gallery(image: Image.Image, prompt: str, metadata: dict | None = Non
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{uuid.uuid4().hex[:8]}.png"
     filepath = GALLERY_DIR / filename
-    # Directory creation moved to initialization step
+    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
     image.save(filepath)
     metadata_file = filepath.with_suffix('.json')
     metadata_info = {


### PR DESCRIPTION
## Summary
- create gallery tab in `ui/web.py` to browse images saved to `CONFIG.gallery_dir`
- add controls to open image files and copy their path
- load gallery images and metadata on startup and after generation
- ensure gallery directory is created when saving
- document the new feature in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb4f707688328b6abd0a143c5be20