### PR TITLE
Add memory stats auto-refresh using gr.Timer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ generation_defaults:
   batch_size: 1
 conda_env: illustrious
 gallery_dir: /tmp/illustrious_ai/gallery
+memory_stats_refresh_interval: 2.0
 
 # Memory Guardian Configuration
 memory_guardian:

--- a/core/config.py
+++ b/core/config.py
@@ -26,6 +26,9 @@ class AppConfig:
     # Memory Guardian settings
     memory_guardian: dict | None = None
 
+    # UI settings
+    memory_stats_refresh_interval: float = 2.0
+
     def __post_init__(self):
         if self.cuda_settings is None:
             self.cuda_settings = {
@@ -63,6 +66,12 @@ def load_config(path: str | None = None) -> AppConfig:
     config.ollama_base_url = os.getenv("OLLAMA_BASE_URL", config.ollama_base_url)
     config.gpu_backend = os.getenv("GPU_BACKEND", config.gpu_backend)
     config.gallery_dir = os.getenv("GALLERY_DIR", config.gallery_dir)
+    refresh_val = os.getenv("MEMORY_STATS_REFRESH_INTERVAL")
+    if refresh_val is not None:
+        try:
+            config.memory_stats_refresh_interval = float(refresh_val)
+        except ValueError:
+            pass
     env_lazy = os.getenv("LOAD_MODELS_ON_STARTUP")
     if env_lazy is not None:
         config.load_models_on_startup = env_lazy.lower() not in ("false", "0", "no")

--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -56,7 +56,7 @@ def save_to_gallery(image: Image.Image, prompt: str, metadata: dict | None = Non
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{timestamp}_{uuid.uuid4().hex[:8]}.png"
     filepath = GALLERY_DIR / filename
-    # Directory creation moved to initialization step
+    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
     image.save(filepath)
     metadata_file = filepath.with_suffix('.json')
     metadata_info = {

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -12,15 +12,18 @@ from core import config
 def test_load_config_file_and_env(tmp_path, monkeypatch):
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        "sd_model: '/tmp/model.pt'\nollama_model: 'test-model'\nollama_base_url: 'http://example.com'"
+        "sd_model: '/tmp/model.pt'\nollama_model: 'test-model'\n"
+        "ollama_base_url: 'http://example.com'\nmemory_stats_refresh_interval: 3.0"
     )
     monkeypatch.setenv("SD_MODEL", "/env/model.pt")
     monkeypatch.setenv("GALLERY_DIR", "/tmp/gallery_env")
+    monkeypatch.setenv("MEMORY_STATS_REFRESH_INTERVAL", "4.0")
     conf = config.load_config(str(cfg))
     assert conf.sd_model == "/env/model.pt"
     assert conf.ollama_model == "test-model"
     assert conf.ollama_base_url == "http://example.com"
     assert conf.gallery_dir == "/tmp/gallery_env"
+    assert conf.memory_stats_refresh_interval == 4.0
 
 
 def test_init_sdxl_missing_model(tmp_path, monkeypatch):

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -18,6 +18,9 @@ def test_model_loader_button(monkeypatch):
             if self.label == "⚡ Load Selected":
                 events['fn'] = fn
             return self
+        def tick(self, fn=None, inputs=None, outputs=None):
+            events['tick_fn'] = fn
+            return self
         def change(self, *a, **k):
             return self
         def submit(self, *a, **k):
@@ -47,7 +50,7 @@ def test_model_loader_button(monkeypatch):
         def __getattr__(self, name):
             if name in ["Blocks", "Row", "Column", "Tab", "Accordion", "Group"]:
                 return DummyBlocks
-            if name in ["Button", "DownloadButton", "Checkbox", "Textbox", "Slider", "Dropdown", "Image", "Chatbot", "File", "JSON", "Code"]:
+            if name in ["Button", "DownloadButton", "Checkbox", "Textbox", "Slider", "Dropdown", "Image", "Chatbot", "File", "JSON", "Code", "Timer"]:
                 return DummyComp
             if name == "Markdown":
                 return lambda *a, **k: None

--- a/ui/web.py
+++ b/ui/web.py
@@ -1062,7 +1062,7 @@ def create_gradio_app(state: AppState):
 
         refresh_timer.tick(
             fn=lambda: (
-                get_memory_stats_markdown(state),
+                get_memory_stats_wrapper(state),
                 get_monitor_status(),
             ),
             outputs=[memory_display, monitor_status],

--- a/ui/web.py
+++ b/ui/web.py
@@ -437,6 +437,7 @@ def create_gradio_app(state: AppState):
 
             gr.Markdown("### Memory Usage")
             memory_display = gr.Markdown(get_memory_stats_wrapper(state))
+            refresh_timer = gr.Timer(value=CONFIG.memory_stats_refresh_interval, render=False)
 
             monitor_status = gr.Textbox(
                 value="",
@@ -1059,7 +1060,15 @@ def create_gradio_app(state: AppState):
             outputs=[monitor_status, memory_display],
         )
 
-        
+        refresh_timer.tick(
+            fn=lambda: (
+                get_memory_stats_markdown(state),
+                get_monitor_status(),
+            ),
+            outputs=[memory_display, monitor_status],
+        )
+
+
         # Initialize model selector and templates on load
         # Skip model initialization if in quick-start mode
         def initialize_ui():


### PR DESCRIPTION
## Summary
- make memory stats refresh interval configurable
- refresh memory stats automatically in the UI using `gr.Timer`
- adapt tests to new timer component
- ensure gallery directory is created when saving images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb4fdc4f88328a70f946e675d5c28