### PR TITLE
Add vision model field to AppState

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -11,6 +11,7 @@ class AppState:
 
     sdxl_pipe: Optional[StableDiffusionXLPipeline] = None
     ollama_model: Optional[str] = None
+    ollama_vision_model: Optional[str] = None
     model_status: Dict[str, bool] = field(
         default_factory=lambda: {"sdxl": False, "ollama": False, "multimodal": False}
     )

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -102,6 +102,7 @@ def test_api_error_handling():
 
         # Create a test app state and FastAPI app
         state = AppState()
+        assert state.ollama_vision_model is None
         app = create_api_app(state, auto_load=False)
         client = TestClient(app)
 

--- a/test_full_functionality.py
+++ b/test_full_functionality.py
@@ -29,6 +29,7 @@ from core.config import CONFIG
 class FunctionalityTester:
     def __init__(self):
         self.state = AppState()
+        assert self.state.ollama_vision_model is None
         self.test_results = {}
         
     def print_header(self, text):

--- a/test_memory_guardian.py
+++ b/test_memory_guardian.py
@@ -27,6 +27,8 @@ def test_memory_stats():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     stats = guardian.get_memory_stats()
@@ -47,6 +49,7 @@ def test_memory_requirements_check():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     # Test different operation types
@@ -69,6 +72,7 @@ def test_intervention_registration():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     # Test callback
@@ -94,6 +98,7 @@ def test_memory_monitoring():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     # Start monitoring
@@ -125,6 +130,7 @@ def test_adaptive_settings():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     # Import the adaptive settings function
@@ -152,6 +158,7 @@ def test_memory_report():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     try:
@@ -178,6 +185,7 @@ def test_configuration():
     print("-" * 40)
     
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian = get_memory_guardian(app_state)
     
     config = guardian.config

--- a/test_model_selection.py
+++ b/test_model_selection.py
@@ -20,6 +20,7 @@ def main():
     
     # Initialize app state
     state = AppState()
+    assert state.ollama_vision_model is None
     
     # Test 1: Get available models
     print("\n1. Scanning for available models...")

--- a/test_regenerate_feature.py
+++ b/test_regenerate_feature.py
@@ -18,6 +18,7 @@ def test_regenerate_state():
     
     # Create state instance
     state = AppState()
+    assert state.ollama_vision_model is None
     
     # Test 1: Initial state
     print("✅ Test 1: Initial state")

--- a/test_simple.py
+++ b/test_simple.py
@@ -64,6 +64,7 @@ def test_llm_only():
     print_header("Testing LLM Only")
     
     state = AppState()
+    assert state.ollama_vision_model is None
     
     # Initialize Ollama
     print_info("Initializing Ollama...")
@@ -96,8 +97,9 @@ def test_image_generation_only():
     
     # Clear CUDA cache
     clear_gpu_memory()
-    
+
     state = AppState()
+    assert state.ollama_vision_model is None
     
     # Initialize SDXL
     print_info("Initializing SDXL...")
@@ -144,6 +146,7 @@ def test_vision_analysis(image_path):
     clear_gpu_memory()
     
     state = AppState()
+    assert state.ollama_vision_model is None
     
     # Initialize Ollama with vision
     print_info("Initializing vision model...")

--- a/tests/test_chat_history_persistence.py
+++ b/tests/test_chat_history_persistence.py
@@ -14,6 +14,7 @@ def test_history_saved_and_loaded(tmp_path, monkeypatch):
     import core.ollama as ollama
 
     state = AppState()
+    assert state.ollama_vision_model is None
     hist_file = tmp_path / "history.json"
     monkeypatch.setattr(ollama, "CHAT_HISTORY_FILE", hist_file)
     monkeypatch.setattr(ollama, "chat_completion", lambda *a, **k: "ai")
@@ -31,6 +32,7 @@ def test_history_saved_and_loaded(tmp_path, monkeypatch):
 
     # Load into new state
     new_state = AppState()
+    assert new_state.ollama_vision_model is None
     monkeypatch.setattr(ollama, "CHAT_HISTORY_FILE", hist_file)
     ollama.load_chat_history(new_state)
     assert new_state.chat_history_store["s1"] == [("hi", "ai")]

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -30,6 +30,8 @@ def test_init_sdxl_missing_model(tmp_path, monkeypatch):
     from core import sdxl
     from core.state import AppState
     state = AppState()
+    assert state.ollama_vision_model is None
+    assert state.ollama_vision_model is None
     monkeypatch.setattr(sdxl.CONFIG, "sd_model", str(tmp_path / "missing.safetensors"))
     result = sdxl.init_sdxl(state)
     assert result is None

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -16,7 +16,9 @@ def test_config_overrides(monkeypatch):
     monkeypatch.setattr(CONFIG, "memory_guardian", custom, raising=False)
     from core.state import AppState
     from core.memory_guardian import MemoryGuardian
-    guardian = MemoryGuardian(AppState())
+    state = AppState()
+    assert state.ollama_vision_model is None
+    guardian = MemoryGuardian(state)
     th = guardian.thresholds
     assert th.low_threshold == 0.60
     assert th.medium_threshold == 0.80
@@ -36,7 +38,9 @@ def test_defaults_preserved(monkeypatch):
     monkeypatch.setattr(CONFIG, "memory_guardian", partial, raising=False)
     from core.state import AppState
     from core.memory_guardian import MemoryGuardian
-    guardian = MemoryGuardian(AppState())
+    state2 = AppState()
+    assert state2.ollama_vision_model is None
+    guardian = MemoryGuardian(state2)
     th = guardian.thresholds
     assert th.low_threshold == 0.70
     assert th.medium_threshold == 0.85

--- a/tests/test_memory_guardian_lifecycle.py
+++ b/tests/test_memory_guardian_lifecycle.py
@@ -10,6 +10,7 @@ def test_guardian_recreated_after_stop():
     from core.memory_guardian import get_memory_guardian
 
     app_state = AppState()
+    assert app_state.ollama_vision_model is None
     guardian1 = start_memory_guardian(app_state)
     stop_memory_guardian()
     guardian2 = start_memory_guardian(app_state)

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -69,6 +69,7 @@ def test_model_loader_button(monkeypatch):
     monkeypatch.setattr(web, 'get_model_status', lambda st: 'ok')
 
     state = AppState()
+    assert state.ollama_vision_model is None
     web.create_gradio_app(state)
     fn = events.get('fn')
     assert fn is not None

--- a/tests/test_model_switching.py
+++ b/tests/test_model_switching.py
@@ -6,6 +6,7 @@ from core.config import CONFIG
 def test_switch_sdxl_model_missing(monkeypatch):
     from core.state import AppState
     state = AppState()
+    assert state.ollama_vision_model is None
     from core import sdxl
     monkeypatch.setattr(os.path, "exists", lambda p: False)
     old = CONFIG.sd_model
@@ -18,6 +19,7 @@ def test_switch_sdxl_model_missing(monkeypatch):
 def test_switch_sdxl_model_success(monkeypatch):
     from core.state import AppState
     state = AppState()
+    assert state.ollama_vision_model is None
     from core import sdxl
     monkeypatch.setattr(os.path, "exists", lambda p: True)
 
@@ -35,6 +37,7 @@ def test_switch_sdxl_model_success(monkeypatch):
 def test_switch_ollama_model(monkeypatch):
     from core.state import AppState
     state = AppState()
+    assert state.ollama_vision_model is None
     state.chat_history_store = {"s": [("hi", "there")]} 
     from core import ollama
 


### PR DESCRIPTION
## Summary
- extend `AppState` with `ollama_vision_model`
- verify new default in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbd0ca9f08328aeb61e165be2def2