### PR TITLE
Start Memory Guardian on MCP server launch

### DIFF
--- a/ai_studio_mcp.py
+++ b/ai_studio_mcp.py
@@ -4,8 +4,6 @@ import threading
 
 from ui.web import create_gradio_app
 from server.api import run_mcp_server
-from core.sdxl import init_sdxl
-from core.ollama import init_ollama
 from core.state import AppState
 
 logger = logging.getLogger(__name__)
@@ -15,8 +13,6 @@ app_state = AppState()
 
 
 if __name__ == "__main__":
-    init_sdxl(app_state)
-    init_ollama(app_state)
     mcp_thread = threading.Thread(target=run_mcp_server, args=(app_state,), daemon=True)
     mcp_thread.start()
     logger.info("MCP Server started on http://localhost:8000")

--- a/server/api.py
+++ b/server/api.py
@@ -144,6 +144,14 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
 
 def run_mcp_server(state: AppState, auto_load: bool = True) -> None:
     import uvicorn
+    from core.memory_guardian import start_memory_guardian, stop_memory_guardian
 
     app = create_api_app(state, auto_load=auto_load)
-    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")
+
+    # Start monitoring before launching the server
+    start_memory_guardian(state)
+    try:
+        uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")
+    finally:
+        # Ensure the guardian is stopped when the server shuts down
+        stop_memory_guardian()

--- a/tests/test_server_memory_guardian.py
+++ b/tests/test_server_memory_guardian.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import types
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+
+def test_guardian_active_on_server_start(monkeypatch):
+    from core.state import AppState
+    import server.api as api
+    from core.memory_guardian import get_memory_guardian
+
+    app_state = AppState()
+    started = {}
+
+    def dummy_run(app, host="0.0.0.0", port=8000, log_level="info"):
+        started['active'] = get_memory_guardian(app_state).is_monitoring
+
+    monkeypatch.setitem(sys.modules, 'uvicorn', types.SimpleNamespace(run=dummy_run))
+    api.run_mcp_server(app_state, auto_load=False)
+
+    assert started.get('active') is True
+


### PR DESCRIPTION
## Summary
- start the Memory Guardian when launching the MCP server and stop it on shutdown
- streamline `ai_studio_mcp.py` startup logic
- test that the Memory Guardian begins monitoring when the server starts

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbf8bd00483288f377592a534a116