### PR TITLE
Add reset controls for Text-to-Image generation

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -955,7 +955,7 @@ def create_gradio_app(state: AppState):
             resolution_def = get_resolution_option(width_def, height_def)
             return (
                 "",
-                "blurry, low quality, text, watermark, deformed",
+                defaults.get("negative_prompt", "blurry, low quality, text, watermark, deformed"),
                 steps_def,
                 guidance_def,
                 -1,

--- a/ui/web.py
+++ b/ui/web.py
@@ -1450,16 +1450,7 @@ def parse_resolution(resolution_string):
 
 def get_resolution_option(width: int, height: int) -> str:
     """Return dropdown option matching the given width and height."""
-    options = [
-        "512x512 (Square - Fast)",
-        "768x768 (Square - Balanced)",
-        "1024x1024 (Square - High Quality)",
-        "768x512 (Landscape)",
-        "512x768 (Portrait)",
-        "1024x768 (Landscape HD)",
-        "768x1024 (Portrait HD)"
-    ]
-    for opt in options:
+    for opt in RESOLUTION_OPTIONS:
         w, h = parse_resolution(opt)
         if w == width and h == height:
             return opt

--- a/ui/web.py
+++ b/ui/web.py
@@ -958,7 +958,7 @@ def create_gradio_app(state: AppState):
                 defaults.get("negative_prompt", "blurry, low quality, text, watermark, deformed"),
                 steps_def,
                 guidance_def,
-                -1,
+                RANDOM_SEED,
                 resolution_def,
                 gr.update(visible=False)
             )


### PR DESCRIPTION
## Summary
- add a Reset button next to generate controls
- implement handler to restore default prompt, params and hide regenerate button
- store resolution option helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc3933c0c8328bdf3deab32ef7221