### PR TITLE
Add Ctrl+Enter generation shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ pytest
 - **Quick Style Buttons**: One-click style application (Anime, Realistic, Artistic, Fantasy, Cyberpunk)
 - **Resolution Selector**: Choose from 7 optimized resolutions (512x512 to 1024x1024, portrait/landscape)
 - Enter prompts or use "Enhance Prompt" for AI improvement
+- Press **Ctrl+Enter** (or **Cmd+Enter** on macOS) to generate
 - Adjust parameters: steps, guidance scale, seed
 - Images auto-saved to gallery
 - **New**: Use saved prompt templates for consistent results

--- a/ui/web.py
+++ b/ui/web.py
@@ -179,7 +179,12 @@ def create_gradio_app(state: AppState):
                             size="sm",
                             elem_classes=["secondary-button"]
                         )
-                    prompt = gr.Textbox(label="Prompt", placeholder="Describe what you want to create...", lines=3)
+                    prompt = gr.Textbox(
+                        label="Prompt",
+                        placeholder="Describe what you want to create...",
+                        lines=3,
+                        elem_id="prompt-box",
+                    )
                     
                     # Quick Style Buttons
                     with gr.Row():
@@ -277,7 +282,8 @@ def create_gradio_app(state: AppState):
                             "🎨 Create Masterpiece",
                             variant="primary",
                             size="lg",
-                            elem_classes=["primary-button"]
+                            elem_classes=["primary-button"],
+                            elem_id="generate-btn",
                         )
                         enhance_btn = gr.Button(
                             "✨ Enhance Vision",
@@ -968,6 +974,22 @@ def create_gradio_app(state: AppState):
 
         demo.load(
             js=f"() => {{ if('{current_theme}' === 'dark') {{ document.documentElement.classList.add('dark'); }} else {{ document.documentElement.classList.remove('dark'); }} }}"
+        )
+
+        demo.load(
+            js="""
+            () => {
+                const box = document.getElementById('prompt-box');
+                const btn = document.getElementById('generate-btn');
+                if (box && btn) {
+                    box.addEventListener('keydown', (e) => {
+                        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                            btn.click();
+                        }
+                    });
+                }
+            }
+            """
         )
 
         def prepare_download(image):


### PR DESCRIPTION
## Summary
- attach `Ctrl+Enter` / `Cmd+Enter` shortcut to prompt textbox
- document shortcut in README

## Testing
- `python test_simple.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bc396b0788328bd0a874f0f349cbd