### PR TITLE
Organize advanced options

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -226,12 +226,6 @@ def create_gradio_app(state: AppState):
                                 visible=False
                             )
                         
-                        negative_prompt = gr.Textbox(
-                            label="Elements to Avoid",
-                            value="blurry, low quality, text, watermark, deformed",
-                            lines=2,
-                            elem_classes=["textbox"]
-                        )
                         with gr.Row():
                             steps = gr.Slider(
                                 10, 100,
@@ -262,21 +256,28 @@ def create_gradio_app(state: AppState):
                                 value="1024x1024 (Square - High Quality)",
                                 elem_classes=["dropdown"]
                             )
-                        seed = gr.Number(
-                            value=-1,
-                            label="Inspiration Seed (-1 for random)",
-                            elem_classes=["number-input"]
-                        )
-                        save_gallery = gr.Checkbox(
-                            value=True,
-                            label="Add to Gallery Collection",
-                            elem_classes=["checkbox-input"]
-                        )
-                        auto_best = gr.Checkbox(
-                            value=False,
-                            label="Auto-Best",
-                            elem_classes=["checkbox-input"]
-                        )
+                        with gr.Accordion("Advanced", open=False):
+                            negative_prompt = gr.Textbox(
+                                label="Elements to Avoid",
+                                value="blurry, low quality, text, watermark, deformed",
+                                lines=2,
+                                elem_classes=["textbox"]
+                            )
+                            seed = gr.Number(
+                                value=-1,
+                                label="Inspiration Seed (-1 for random)",
+                                elem_classes=["number-input"]
+                            )
+                            save_gallery = gr.Checkbox(
+                                value=True,
+                                label="Add to Gallery Collection",
+                                elem_classes=["checkbox-input"]
+                            )
+                            auto_best = gr.Checkbox(
+                                value=False,
+                                label="Auto-Best",
+                                elem_classes=["checkbox-input"]
+                            )
                     with gr.Row():
                         generate_btn = gr.Button(
                             "🎨 Create Masterpiece",


### PR DESCRIPTION
## Summary
- group negative prompt, seed, and gallery settings in an "Advanced" accordion
- keep layout simpler by hiding advanced controls by default

## Testing
- `pytest tests/test_model_loader.py::test_model_loader_button -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684bc4f0fb3c832891b36be45f6eac24