### PR TITLE
Add gallery filtering

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -58,7 +58,7 @@ def create_gradio_app(state: AppState):
                 with open(GALLERY_FILTER_FILE, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     return data.get("search", ""), data.get("tags", "")
-        except Exception as e:  # pragma: no cover - non-critical
+        except (json.JSONDecodeError, IOError) as e:  # pragma: no cover - non-critical
             logger.error("Error loading gallery filter: %s", e)
         return "", ""
 


### PR DESCRIPTION
## Summary
- enhance gallery filtering to use search text and tags
- add search UI to the gallery page
- refresh gallery with filters when project or generation events occur
- persist gallery filter settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bc35c56bc832890e3529d66af6da5