### PR TITLE
Update gallery README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ pytest
 - Browse saved images in a gallery view
 - View metadata, open files, or copy their paths
 - Use the project selector to switch between different galleries
+- Search images by name or metadata
+- Filter by tags to focus on specific categories
+- Filter settings persist across sessions via files in `TEMP_DIR`
 
 ### 📝 Prompt Templates Tab ✨ **NEW**
 - **Save Templates**: Save your best prompts for reuse


### PR DESCRIPTION
## Summary
- document gallery search feature
- explain tag filtering
- mention that filters persist via `TEMP_DIR`

## Testing
- `pytest test_simple.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bc720c298832899c9b1929c2bdaf2