### PR TITLE
Add runtime memory guardian tuning

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,17 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument("--open-browser", action="store_true", help="Open browser on launch")
     parser.add_argument("--optimize-memory", action="store_true", help="Enable memory optimizations")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--memory-profile",
+        choices=["conservative", "balanced", "aggressive"],
+        help="Set memory guardian profile",
+    )
+    parser.add_argument(
+        "--memory-threshold",
+        action="append",
+        metavar="LEVEL:PERCENT",
+        help="Override memory threshold (can be repeated)",
+    )
     return parser
 
 class IllustriousAIStudio:
@@ -127,7 +138,20 @@ class IllustriousAIStudio:
 
         # Start Memory Guardian
         self.logger.info("🛡️ Starting Memory Guardian...")
-        start_memory_guardian(self.app_state)
+        guardian = start_memory_guardian(self.app_state)
+        if self.args.memory_profile:
+            try:
+                guardian.set_profile(self.args.memory_profile)
+                self.logger.info("Memory profile set to %s", self.args.memory_profile)
+            except ValueError as e:
+                self.logger.error("%s", e)
+        if self.args.memory_threshold:
+            for th in self.args.memory_threshold:
+                try:
+                    level, val = th.split(":")
+                    guardian.set_threshold(level, float(val))
+                except Exception as e:
+                    self.logger.error("Invalid threshold '%s': %s", th, e)
         self.logger.info("✅ Memory Guardian started")
         
         # Model initialization with progress feedback

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -155,3 +155,19 @@ def test_switch_models_endpoint(monkeypatch):
     assert resp.status_code == 200
     assert calls['sdxl'] == 'a'
     assert calls['ollama'] == 'b'
+
+
+def test_memory_profile_endpoint():
+    client = get_client()
+    resp = client.post('/memory-profile', json={"profile": "conservative"})
+    assert resp.status_code == 200
+    assert resp.json()["profile"] == "conservative"
+
+
+def test_memory_thresholds_endpoint():
+    client = get_client()
+    resp = client.post('/memory-thresholds', json={"low": 60, "critical": 99})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["low"] == "60%"
+    assert data["critical"] == "99%"

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -14,6 +14,8 @@ def test_defaults():
     assert args.web_port == 7860
     assert args.api_port == 8000
     assert args.log_level == "INFO"
+    assert args.memory_profile is None
+    assert args.memory_threshold is None
 
 
 def test_flags_and_ports():
@@ -24,3 +26,14 @@ def test_flags_and_ports():
     assert args.no_api is True
     assert args.web_port == 9000
     assert args.api_port == 1234
+
+def test_memory_cli_options():
+    from main import create_parser
+    parser = create_parser()
+    args = parser.parse_args([
+        "--memory-profile", "aggressive",
+        "--memory-threshold", "low:60",
+        "--memory-threshold", "high:90",
+    ])
+    assert args.memory_profile == "aggressive"
+    assert args.memory_threshold == ["low:60", "high:90"]

--- a/tests/test_memory_manager_cli.py
+++ b/tests/test_memory_manager_cli.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+from memory_manager import create_parser
+
+
+def test_memory_manager_args():
+    parser = create_parser()
+    args = parser.parse_args(["--profile", "balanced", "--threshold", "low:65", "--threshold", "high:90"])
+    assert args.profile == "balanced"
+    assert args.threshold == ["low:65", "high:90"]

--- a/tests/test_memory_profile_runtime.py
+++ b/tests/test_memory_profile_runtime.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+from core.state import AppState
+from core.memory_guardian import MemoryGuardian, PROFILE_PRESETS
+
+def test_profile_update_runtime():
+    guardian = MemoryGuardian(AppState())
+    guardian.set_profile("aggressive")
+    assert guardian.config["profile"] == "aggressive"
+    assert guardian.thresholds.low_threshold == PROFILE_PRESETS["aggressive"]["low"]
+
+
+def test_set_threshold_runtime():
+    guardian = MemoryGuardian(AppState())
+    guardian.set_threshold("medium", 75)
+    assert guardian.thresholds.medium_threshold == 0.75

--- a/ui/web.py
+++ b/ui/web.py
@@ -667,11 +667,11 @@ def create_gradio_app(state: AppState):
                 med_slider = gr.Slider(50, 100, value=int(guardian_cfg.thresholds.medium_threshold*100), label="Medium %")
                 high_slider = gr.Slider(50, 100, value=int(guardian_cfg.thresholds.high_threshold*100), label="High %")
                 crit_slider = gr.Slider(50, 100, value=int(guardian_cfg.thresholds.critical_threshold*100), label="Critical %")
-            apply_thresholds_btn = gr.Button(
-                "Apply Thresholds",
-                variant="secondary",
-                elem_classes=["secondary-button"],
-            )
+                apply_thresholds_btn = gr.Button(
+                    "Apply Thresholds",
+                    variant="secondary",
+                    elem_classes=["secondary-button"],
+                )
 
             gr.Markdown("### Model Loader")
             with gr.Row():


### PR DESCRIPTION
## Summary
- expose profile and threshold updates via memory_manager CLI
- allow setting memory profile/thresholds at startup in main app
- implement runtime update APIs in memory_guardian
- provide API endpoints and UI controls for memory profile and thresholds
- add tests for new CLI options, API endpoints, and guardian runtime updates

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c148db3108328997b50a26c3ee30f