### PR TITLE
Use RANDOM_SEED constant in web UI

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -306,7 +306,7 @@ def create_gradio_app(state: AppState):
                             )
                             seed = gr.Number(
                                 value=RANDOM_SEED,
-                                label=f"Inspiration Seed ({RANDOM_SEED} for random)",
+                                label="Inspiration Seed (-1 for random)",
                                 elem_classes=["number-input"]
                             )
                             save_gallery = gr.Checkbox(

--- a/ui/web.py
+++ b/ui/web.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 
 THEME_PREF_FILE = TEMP_DIR / "theme_pref.json"
 
+# Special value representing a random seed for image generation
+RANDOM_SEED = -1
+
 def create_gradio_app(state: AppState):
     """Build and return the Gradio UI for the application."""
     css_file = (Path(__file__).parent / "custom.css").read_text()
@@ -302,8 +305,8 @@ def create_gradio_app(state: AppState):
                                 elem_classes=["textbox"]
                             )
                             seed = gr.Number(
-                                value=-1,
-                                label="Inspiration Seed (-1 for random)",
+                                value=RANDOM_SEED,
+                                label=f"Inspiration Seed ({RANDOM_SEED} for random)",
                                 elem_classes=["number-input"]
                             )
                             save_gallery = gr.Checkbox(


### PR DESCRIPTION
## Summary
- define `RANDOM_SEED` constant in `ui/web.py`
- use the constant for the seed field
- return `RANDOM_SEED` when resetting controls

## Testing
- `pip install -q pillow pyyaml psutil httpx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684c18025a988328b1c257689d3add84