### PR TITLE
Improve gallery responsiveness

### DIFF
--- a/ui/custom.css
+++ b/ui/custom.css
@@ -153,11 +153,19 @@ h1 {
 /* Gallery wall */
 .gallery-section {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 1.5rem;
     padding: 1.5rem;
     background: var(--canvas-color);
     border-radius: 12px;
+    width: 100%;
+}
+
+@media (max-width: 600px) {
+    .gallery-section {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1rem;
+    }
 }
 
 .gallery-item {

--- a/ui/web.py
+++ b/ui/web.py
@@ -585,7 +585,7 @@ def create_gradio_app(state: AppState):
             gallery_component = gr.Gallery(
                 label="Gallery",
                 elem_classes=["gallery-section"],
-                columns=4,
+                columns=[1, 2, 3, 4],
                 height="auto",
             )
             metadata_display = gr.JSON(label="Metadata")


### PR DESCRIPTION
## Summary
- compute gallery column count using Gradio's responsive list
- tweak gallery CSS for mobile screens

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: cannot import fastapi modules and heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b1ee0dc8328b887c5d0c2848d19