### PR TITLE
Refactor SDXL generation API

### DIFF
--- a/core/ollama.py
+++ b/core/ollama.py
@@ -302,7 +302,13 @@ def handle_chat(state: AppState, message: str, session_id: str = "default", chat
             response = (
                 f"🎨 I'll create an image with this enhanced prompt:\n\n'{enhanced_prompt}'\n\nGenerating now..."
             )
-            image, status = generate_image(state, enhanced_prompt, save_to_gallery_flag=False)
+            image, status = generate_image(
+                state,
+                {
+                    "prompt": enhanced_prompt,
+                    "save_to_gallery_flag": False,
+                },
+            )
             if image:
                 saved_path = save_to_gallery(
                     state,

--- a/core/state.py
+++ b/core/state.py
@@ -22,6 +22,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Optional, Dict, List, Tuple, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sdxl import ModelProtocol
+else:
+    ModelProtocol = Any
 from PIL import Image
 
 # Import pipeline type only for type checking to avoid runtime import issues
@@ -62,7 +67,7 @@ class AppState:
     # AI MODEL INSTANCES
     # ==============================================================
     
-    sdxl_pipe: Optional["StableDiffusionXLPipeline"] = None
+    sdxl_pipe: Optional[ModelProtocol] = None
     """
     Loaded Stable Diffusion XL pipeline instance.
     

--- a/server/api.py
+++ b/server/api.py
@@ -165,17 +165,20 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
                     detail=f"❌ Invalid seed value: {request.seed}. Must be -1 (random) or between 0 and {2**32-1}."
                 )
             
-            logger.info(f"API: Generating image with prompt='{request.prompt[:50]}...', steps={request.steps}, guidance={request.guidance}, seed={request.seed}")
-            
-            # Generate image with improved error handling
-            image, status_msg = generate_image(
-                state,
-                request.prompt,
-                request.negative_prompt,
-                request.steps,
-                request.guidance,
-                request.seed,
+            logger.info(
+                f"API: Generating image with prompt='{request.prompt[:50]}...', steps={request.steps}, guidance={request.guidance}, seed={request.seed}"
             )
+
+            params = {
+                "prompt": request.prompt,
+                "negative_prompt": request.negative_prompt,
+                "steps": request.steps,
+                "guidance": request.guidance,
+                "seed": request.seed,
+            }
+
+            # Generate image with improved error handling
+            image, status_msg = generate_image(state, params)
             
             if image is None:
                 code = 507 if "out of memory" in status_msg.lower() else 500

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def stub_dependencies():
                 pass
             def to(self, device):
                 pass
-            def __call__(self, *args, **kwargs):
+            def generate(self, *args, **kwargs):
                 from PIL import Image
                 return types.SimpleNamespace(images=[Image.new('RGB', (64,64), 'white')])
         diff.StableDiffusionXLPipeline = DummyPipe

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -44,7 +44,7 @@ def load_app():
 
 # Dummy implementations
 class DummyPipe:
-    def __call__(self, *args, **kwargs):
+    def generate(self, *args, **kwargs):
         return types.SimpleNamespace(images=[Image.new('RGB', (64, 64), 'blue')])
 
 def dummy_chat_completion(messages, temperature=0.7, max_tokens=256):
@@ -60,7 +60,7 @@ def setup_app(monkeypatch):
     app.app_state.ollama_model = 'dummy'
     app.app_state.model_status.update({'sdxl': True, 'ollama': True, 'multimodal': True})
     import server.api as api
-    monkeypatch.setattr(api, 'generate_image', lambda state, *a, **k: (Image.new('RGB',(64,64),'blue'), 'done'))
+    monkeypatch.setattr(api, 'generate_image', lambda state, params: (Image.new('RGB',(64,64),'blue'), 'done'))
     monkeypatch.setattr(api, 'chat_completion', lambda state, *a, **k: dummy_chat_completion(*a, **k))
     monkeypatch.setattr(api, 'analyze_image', lambda state, img, q='': dummy_analyze_image(img, q))
     monkeypatch.setattr(app, 'clear_gpu_memory', lambda: None)

--- a/tests/test_full_functionality.py
+++ b/tests/test_full_functionality.py
@@ -128,11 +128,13 @@ class FunctionalityTester:
         try:
             image, status = generate_image(
                 self.state,
-                prompt,
-                negative_prompt="blurry, low quality, text, watermark",
-                steps=30,
-                guidance=7.5,
-                seed=42  # Fixed seed for reproducibility
+                {
+                    "prompt": prompt,
+                    "negative_prompt": "blurry, low quality, text, watermark",
+                    "steps": 30,
+                    "guidance": 7.5,
+                    "seed": 42,
+                },
             )
             
             if image:

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -40,7 +40,7 @@ def load_app():
     return importlib.import_module('app')
 
 class DummyPipe:
-    def __call__(self, *args, **kwargs):
+    def generate(self, *args, **kwargs):
         return types.SimpleNamespace(images=[Image.new('RGB', (64, 64), color='white')])
 
 # Ensure clear_gpu_memory is patched to avoid torch calls
@@ -53,7 +53,7 @@ def patch_clear_cuda(monkeypatch):
 def test_generate_image_no_model(monkeypatch):
     app = load_app()
     app.app_state.sdxl_pipe = None
-    image, status = app.generate_image(app.app_state, 'test')
+    image, status = app.generate_image(app.app_state, {"prompt": 'test'})
     assert image is None
     assert 'model not loaded' in status.lower()
 
@@ -61,6 +61,9 @@ def test_generate_image_no_model(monkeypatch):
 def test_generate_image_success(monkeypatch):
     app = load_app()
     app.app_state.sdxl_pipe = DummyPipe()
-    img, status = app.generate_image(app.app_state, 'test prompt', save_to_gallery_flag=False)
+    img, status = app.generate_image(
+        app.app_state,
+        {"prompt": 'test prompt', "save_to_gallery_flag": False}
+    )
     assert isinstance(img, Image.Image)
     assert 'successfully' in status.lower()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -12,12 +12,17 @@ from pathlib import Path
 from PIL import Image
 import torch
 from colorama import init, Fore, Style
+import shutil
+import pytest
 
 # Set environment variables BEFORE importing our modules
 os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'expandable_segments:True'
 os.environ['OLLAMA_KEEP_ALIVE'] = '0'  # Unload models immediately after use
 
 init(autoreset=True)
+
+if shutil.which('ollama') is None:
+    pytest.skip("Ollama not installed", allow_module_level=True)
 
 # Import our modules
 from core.state import AppState
@@ -112,11 +117,13 @@ def test_image_generation_only():
         
         image, status = generate_image(
             state,
-            prompt,
-            negative_prompt="blurry, low quality",
-            steps=20,  # Fewer steps for faster generation
-            guidance=7.5,
-            seed=42
+            {
+                "prompt": prompt,
+                "negative_prompt": "blurry, low quality",
+                "steps": 20,
+                "guidance": 7.5,
+                "seed": 42,
+            },
         )
         
         if image:

--- a/ui/web.py
+++ b/ui/web.py
@@ -1324,7 +1324,7 @@ def create_gradio_app(state: AppState):
                     "steps": params["steps"],
                     "guidance": params["guidance"],
                     "seed": params["seed"],
-                    "save_to_gallery_flag": params["save_gallery"],
+                    "save_to_gallery_flag": params["save_to_gallery_flag"],
                     "width": params["width"],
                     "height": params["height"],
                     "progress_callback": cb,

--- a/ui/web.py
+++ b/ui/web.py
@@ -1257,7 +1257,18 @@ def create_gradio_app(state: AppState):
                 def cb(step, total):
                     progress(step/total, desc=f"{step}/{total}")
 
-                image, status = generate_image(state, p, n, st, g, se, save_flag, width, height, progress_callback=cb)
+                params = {
+                    "prompt": p,
+                    "negative_prompt": n,
+                    "steps": st,
+                    "guidance": g,
+                    "seed": se,
+                    "save_to_gallery_flag": save_flag,
+                    "width": width,
+                    "height": height,
+                    "progress_callback": cb,
+                }
+                image, status = generate_image(state, params)
                 progress(1)
                 
                 # Store parameters for regenerate functionality if generation was successful
@@ -1307,15 +1318,17 @@ def create_gradio_app(state: AppState):
 
             image, status = generate_image(
                 state,
-                params["prompt"],
-                params["negative_prompt"],
-                params["steps"],
-                params["guidance"],
-                params["seed"],
-                params["save_gallery"],
-                params["width"],
-                params["height"],
-                progress_callback=cb
+                {
+                    "prompt": params["prompt"],
+                    "negative_prompt": params["negative_prompt"],
+                    "steps": params["steps"],
+                    "guidance": params["guidance"],
+                    "seed": params["seed"],
+                    "save_to_gallery_flag": params["save_gallery"],
+                    "width": params["width"],
+                    "height": params["height"],
+                    "progress_callback": cb,
+                },
             )
             progress(1)
             


### PR DESCRIPTION
## Summary
- formalize SDXL interface with `ModelProtocol`
- wrap diffusers pipeline with `DiffusersPipelineAdapter`
- define `GenerationParams` TypedDict and update `generate_image`
- adjust API, UI and tests to pass new parameter dict
- skip `test_simple` when `ollama` binary is missing

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c78aa6fb083288cf70562b97ccda3