### PR TITLE
Add async generate_image wrapper

### DIFF
--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -47,6 +47,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple, List, Dict, TypedDict, Protocol, Callable, Any
+import asyncio
 
 from PIL import Image
 import torch
@@ -475,6 +476,11 @@ def generate_image(state: AppState, params: GenerationParams) -> Tuple[Optional[
         "❌ Generation failed after all retries. "
         "Check GPU memory or model path and review the README's Logging and Debugging section."
     )
+
+
+async def generate_image_async(state: AppState, params: GenerationParams) -> Tuple[Optional[Image.Image], str]:
+    """Asynchronous wrapper for ``generate_image`` running in a thread."""
+    return await asyncio.to_thread(generate_image, state, params)
 
 def _estimate_generation_memory(width: int, height: int, steps: int) -> float:
     """Estimate memory requirements for image generation in GB"""

--- a/ui/web.py
+++ b/ui/web.py
@@ -51,12 +51,13 @@ import gradio as gr
 
 # Image generation and model management
 from core.sdxl import (
-    generate_image, 
-    TEMP_DIR, 
-    get_latest_image, 
-    init_sdxl, 
-    get_available_models, 
-    get_current_model_info, 
+    generate_image,
+    generate_image_async,
+    TEMP_DIR,
+    get_latest_image,
+    init_sdxl,
+    get_available_models,
+    get_current_model_info,
     test_model_generation, 
     switch_sdxl_model, 
     PROJECTS_DIR
@@ -1150,7 +1151,7 @@ def create_gradio_app(state: AppState):
         enhance_btn.click(fn=lambda p: generate_prompt(state, p), inputs=prompt, outputs=prompt)
         
         # Updated generate button to use wrapper and update recent prompts
-        def generate_and_update_history(p, n, st, g, se, save_flag, res, auto_flag, progress=gr.Progress()):
+        async def generate_and_update_history(p, n, st, g, se, save_flag, res, auto_flag, progress=gr.Progress()):
             # Enhanced UI parameter validation
             try:
                 # Debug logging to understand what's being passed
@@ -1268,7 +1269,7 @@ def create_gradio_app(state: AppState):
                     "height": height,
                     "progress_callback": cb,
                 }
-                image, status = generate_image(state, params)
+                image, status = await generate_image_async(state, params)
                 progress(1)
                 
                 # Store parameters for regenerate functionality if generation was successful
@@ -1304,7 +1305,7 @@ def create_gradio_app(state: AppState):
                 )
         
         # Regenerate function
-        def regenerate_image(progress=gr.Progress()):
+        async def regenerate_image(progress=gr.Progress()):
             if state.last_generation_params is None:
                 return (
                     None,
@@ -1316,7 +1317,7 @@ def create_gradio_app(state: AppState):
             def cb(step, total):
                 progress(step/total, desc=f"{step}/{total}")
 
-            image, status = generate_image(
+            image, status = await generate_image_async(
                 state,
                 {
                     "prompt": params["prompt"],


### PR DESCRIPTION
## Summary
- add `generate_image_async` using `asyncio.to_thread` in `core/sdxl.py`
- use the asynchronous image generation wrapper in `ui/web.py`

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7bf20064832881c4a570eac6567c