### PR TITLE
Add quick generate toolbar

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -1535,12 +1535,12 @@ def create_gradio_app(state: AppState):
                 outputs=[live_status],
             )
 
-        try:
-            quick_generate_btn.click(
+        def configure_quick_generate_btn(include_js):
+            click_chain = quick_generate_btn.click(
                 fn=quick_generate_image,
                 inputs=[prompt, negative_prompt],
                 outputs=[output_image, generation_status, recent_prompts, regenerate_btn],
-                js=show_loading_js,
+                js=show_loading_js if include_js else None,
             ).then(
                 fn=refresh_gallery,
                 inputs=None,


### PR DESCRIPTION
## Summary
- add helper functions and imports for random prompts and presets
- insert quick action buttons above the Generate button
- wire up new buttons to trigger quick generate, restore settings, and load random prompts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684c8ff75e208328beb7e82575d31d24