### PR TITLE
Add creative prompts and user stats

### DIFF
--- a/core/ollama.py
+++ b/core/ollama.py
@@ -269,6 +269,44 @@ def generate_prompt(state: AppState, user_input: str) -> str:
     return enhanced if not enhanced.startswith("❌") else user_input
 
 
+def generate_creative_prompt(state: AppState, user_input: str, style: str = "enhance") -> str:
+    """Generate creative prompts with different styles."""
+
+    style_prompts = {
+        "enhance": (
+            "Transform this idea into a detailed, visually stunning prompt. "
+            "Add artistic details, lighting, atmosphere, and quality tags. "
+            "Be creative but keep the core concept."
+        ),
+        "dreamy": (
+            "Make this idea ethereal and dreamlike. Add soft, magical elements, "
+            "pastel colors, and a sense of wonder. Make it feel like a beautiful dream."
+        ),
+        "epic": (
+            "Transform this into an epic, dramatic scene. Add grand scale, "
+            "dramatic lighting, and a sense of awe and adventure."
+        ),
+        "fun": (
+            "Make this playful and fun! Add bright colors, whimsical elements, "
+            "and a sense of joy and humor."
+        ),
+        "artistic": (
+            "Transform this into a fine art piece. Reference art movements, "
+            "painting techniques, and artistic styles."
+        ),
+    }
+
+    system_prompt = style_prompts.get(style, style_prompts["enhance"])
+
+    messages = [
+        {"role": "system", "content": f"You are a creative AI artist. {system_prompt}"},
+        {"role": "user", "content": f"Create a prompt for: {user_input}"},
+    ]
+
+    enhanced = chat_completion(state, messages, temperature=0.9, max_tokens=150)
+    return enhanced if not enhanced.startswith("❌") else user_input
+
+
 def _execute_tool_command(command: str) -> str:
     """Parse and execute a /tool command."""
     parts = command.strip().split()

--- a/core/user_stats.py
+++ b/core/user_stats.py
@@ -11,7 +11,7 @@ class UserStats:
 
     def __init__(self) -> None:
         self.stats_file = Path("user_data/stats.json")
-        self.stats_file.parent.mkdir(exist_ok=True)
+        self.stats_file.parent.mkdir(parents=True, exist_ok=True)
         self.load_stats()
 
     def load_stats(self) -> None:

--- a/core/user_stats.py
+++ b/core/user_stats.py
@@ -36,7 +36,6 @@ class UserStats:
                 "total_chats": 0,
                 "favorite_styles": {},
                 "daily_creations": {},
-                "achievements": [],
                 "creation_times": [],
             }
 

--- a/core/user_stats.py
+++ b/core/user_stats.py
@@ -1,0 +1,100 @@
+"""User statistics tracking utilities."""
+
+import json
+from pathlib import Path
+from datetime import datetime, date
+from typing import Dict, Any
+
+
+class UserStats:
+    """Track user creation statistics."""
+
+    def __init__(self) -> None:
+        self.stats_file = Path("user_data/stats.json")
+        self.stats_file.parent.mkdir(exist_ok=True)
+        self.load_stats()
+
+    def load_stats(self) -> None:
+        """Load user statistics."""
+        if self.stats_file.exists():
+            with open(self.stats_file) as f:
+                self.data = json.load(f)
+        else:
+            self.data = {
+                "total_images": 0,
+                "total_chats": 0,
+                "favorite_styles": {},
+                "daily_creations": {},
+                "achievements": [],
+                "creation_times": [],
+            }
+
+    def track_creation(self, style: str = "default") -> None:
+        """Track a new image creation."""
+        self.data["total_images"] += 1
+
+        self.data["favorite_styles"][style] = self.data["favorite_styles"].get(style, 0) + 1
+
+        today = date.today().isoformat()
+        self.data["daily_creations"][today] = self.data["daily_creations"].get(today, 0) + 1
+
+        self.data["creation_times"].append(datetime.now().isoformat())
+
+        self.save_stats()
+
+    def get_streak(self) -> int:
+        """Calculate current daily streak."""
+        if not self.data["daily_creations"]:
+            return 0
+
+        dates = sorted(self.data["daily_creations"].keys(), reverse=True)
+        streak = 0
+        current_date = date.today()
+
+        for date_str in dates:
+            check_date = date.fromisoformat(date_str)
+            if (current_date - check_date).days == streak:
+                streak += 1
+            else:
+                break
+
+        return streak
+
+    def get_stats_display(self) -> str:
+        """Get formatted stats for display."""
+        total = self.data["total_images"]
+        favorites = len([k for k, v in self.data["favorite_styles"].items() if v > 2])
+        streak = self.get_streak()
+
+        return f"""
+        ### 📊 Your Creative Stats
+        🎨 Images Created: {total}  
+        ⭐ Favorite Styles: {favorites}  
+        🎯 Current Streak: {streak} days
+        🏆 Next Achievement: {self.get_next_achievement()}
+        """
+
+    def get_next_achievement(self) -> str:
+        """Get the next achievement to work towards."""
+        total = self.data["total_images"]
+
+        milestones = [
+            (1, "First Creation"),
+            (5, "Getting Started"),
+            (10, "Creative Explorer"),
+            (25, "Art Enthusiast"),
+            (50, "Prolific Creator"),
+            (100, "Master Artist"),
+        ]
+
+        for count, title in milestones:
+            if total < count:
+                return f"{title} ({total}/{count})"
+
+        return "Legendary Creator!"
+
+    def save_stats(self) -> None:
+        """Save statistics to file."""
+        with open(self.stats_file, "w") as f:
+            json.dump(self.data, f, indent=2)
+

--- a/core/user_stats.py
+++ b/core/user_stats.py
@@ -18,7 +18,18 @@ class UserStats:
         """Load user statistics."""
         if self.stats_file.exists():
             with open(self.stats_file) as f:
-                self.data = json.load(f)
+                try:
+                    self.data = json.load(f)
+                except json.JSONDecodeError:
+                    print("Warning: The stats file is corrupted. Reinitializing data.")
+                    self.data = {
+                        "total_images": 0,
+                        "total_chats": 0,
+                        "favorite_styles": {},
+                        "daily_creations": {},
+                        "achievements": [],
+                        "creation_times": [],
+                    }
         else:
             self.data = {
                 "total_images": 0,


### PR DESCRIPTION
## Summary
- extend `core/ollama.py` with `generate_creative_prompt`
- track user statistics in new `core/user_stats.py`

## Testing
- `pip install -r requirements-test.txt` *(fails: ModuleNotFoundError: No module named 'diffusers')*
- `pytest -k simple -q` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_e_684da0bca7008328a2b9e53c5f8ff714