### PR TITLE
Fix progress callback error handling

### DIFF
--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -401,7 +401,7 @@ def generate_image(state: AppState, params: GenerationParams) -> Tuple[Optional[
                     try:
                         progress_callback(step + 1, steps)
                     except (TypeError, ValueError, RuntimeError) as e:
-                        logger.warning(f"Progress callback failed: {e}")
+                        logger.exception(f"Progress callback failed: {e}")
 
             result = state.sdxl_pipe.generate(
                 prompt,


### PR DESCRIPTION
## Summary
- handle exceptions in progress callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684db4d1bfbc8328a058bdce910b945f