### PR TITLE
Enable CORS for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A powerful local AI application that combines **Stable Diffusion XL (SDXL)** ima
 ### 🌐 **Dual Interface**
 - **Gradio Web UI** (Port 7860): Interactive web interface with tabs for all features
 - **FastAPI MCP Server** (Port 8000): RESTful API for programmatic access
+  with CORS enabled for the Web UI at `http://localhost:7860`
 
 ### 📸 **Enhanced User Experience** ✨ **NEW**
 - **Recent Prompts**: Quick access to your last 20 prompts for faster iteration

--- a/server/api.py
+++ b/server/api.py
@@ -35,6 +35,7 @@ import base64
 import io
 import logging
 from fastapi import FastAPI, HTTPException, Depends, Request
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from PIL import Image
 import torch
@@ -106,6 +107,14 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
         title="Illustrious AI MCP Server",
         version="1.0.0",
         description="AI Studio API providing image generation, chat, and analysis capabilities"
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:7860"],
+        allow_credentials=True,
+        allow_methods=["GET", "POST"],
+        allow_headers=["*"],
+        max_age=3600,
     )
     
     # Store application state for dependency injection


### PR DESCRIPTION
## Summary
- enable CORS in the FastAPI server
- document CORS in README

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: test_parse_resolution_empty_string, test_save_gallery_creates_directory, test_guardian_active_on_server_start)*

------
https://chatgpt.com/codex/tasks/task_e_684db749ac90832899dfe5a74009a137