### PR TITLE
Improve analyze_image validation

### DIFF
--- a/core/ollama.py
+++ b/core/ollama.py
@@ -418,9 +418,17 @@ def handle_chat(state: AppState, message: str, session_id: str = "default", chat
 def analyze_image(state: AppState, image: Image.Image, question: str = "Describe this image in detail") -> str:
     if not image:
         return "Please upload an image first."
-    if not state.model_status["multimodal"] or not hasattr(state, 'ollama_vision_model'):
+    if not state.model_status["multimodal"] or not hasattr(state, "ollama_vision_model"):
         return "❌ Ollama vision model not available. Please ensure a vision-capable model is configured."
+
     try:
+        width, height = image.size
+        if width * height > 4096 * 4096:
+            return "❌ Image exceeds 16MP limit."
+        if width > 1920 or height > 1920:
+            image = image.copy()
+            image.thumbnail((1920, 1920), Image.Resampling.LANCZOS)
+
         buffered = io.BytesIO()
         image.save(buffered, format="PNG")
         img_base64 = base64.b64encode(buffered.getvalue()).decode()

--- a/core/ollama.py
+++ b/core/ollama.py
@@ -423,7 +423,7 @@ def analyze_image(state: AppState, image: Image.Image, question: str = "Describe
 
     try:
         width, height = image.size
-        if width * height > 4096 * 4096:
+        if width * height > MAX_IMAGE_PIXELS:
             return "❌ Image exceeds 16MP limit."
         if width > 1920 or height > 1920:
             image = image.copy()

--- a/tests/test_analyze_image_validation.py
+++ b/tests/test_analyze_image_validation.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from PIL import Image
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+from core.state import AppState
+import types
+
+
+def load_analyze_image():
+    if 'core.sdxl' not in sys.modules:
+        dummy = types.ModuleType('core.sdxl')
+        dummy.generate_image = lambda *a, **k: None
+        dummy.save_to_gallery = lambda *a, **k: None
+        dummy.TEMP_DIR = '/tmp'
+        sys.modules['core.sdxl'] = dummy
+    return __import__('core.ollama', fromlist=['analyze_image']).analyze_image
+
+
+def test_analyze_image_rejects_large_image():
+    analyze_image = load_analyze_image()
+
+    state = AppState()
+    state.model_status["multimodal"] = True
+    state.ollama_vision_model = "dummy"
+
+    img = Image.new("RGB", (5000, 4000))  # 20MP > 16MP
+    result = analyze_image(state, img)
+    assert result.startswith("❌") and "16MP" in result


### PR DESCRIPTION
## Summary
- enforce 16MP limit and optional resizing in `analyze_image`
- add unit test for image size validation

## Testing
- `pytest -q tests/test_analyze_image_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_684dbc50e188832889ddbd7d13dc3511