### PR TITLE
Refactor memory guardian handling

### DIFF
--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -480,25 +480,19 @@ class MemoryGuardian:
         
         return has_memory
 
-# Global instance
-_memory_guardian = None
+def get_memory_guardian(app_state) -> MemoryGuardian:
+    """Retrieve the memory guardian tied to the given AppState."""
+    return app_state.memory_guardian
 
-def get_memory_guardian(app_state=None) -> MemoryGuardian:
-    """Get the global memory guardian instance"""
-    global _memory_guardian
-    if _memory_guardian is None:
-        _memory_guardian = MemoryGuardian(app_state)
-    return _memory_guardian
 
-def start_memory_guardian(app_state=None):
-    """Start the global memory guardian"""
-    guardian = get_memory_guardian(app_state)
+def start_memory_guardian(app_state):
+    """Start monitoring using the AppState's memory guardian."""
+    guardian = app_state.memory_guardian
     guardian.start_monitoring()
     return guardian
 
-def stop_memory_guardian():
-    """Stop the global memory guardian"""
-    global _memory_guardian
-    if _memory_guardian:
-        _memory_guardian.stop_monitoring()
-        _memory_guardian = None
+
+def stop_memory_guardian(app_state):
+    """Stop monitoring using the AppState's memory guardian."""
+    if hasattr(app_state, "memory_guardian"):
+        app_state.memory_guardian.stop_monitoring()

--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -494,5 +494,4 @@ def start_memory_guardian(app_state):
 
 def stop_memory_guardian(app_state):
     """Stop monitoring using the AppState's memory guardian."""
-    if hasattr(app_state, "memory_guardian"):
-        app_state.memory_guardian.stop_monitoring()
+    app_state.memory_guardian.stop_monitoring()

--- a/core/state.py
+++ b/core/state.py
@@ -181,6 +181,12 @@ class AppState:
 
     _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
+    # ==============================================================
+    # INTERNAL MEMORY GUARDIAN
+    # ==============================================================
+
+    _memory_guardian: Optional["MemoryGuardian"] = field(default=None, init=False, repr=False)
+
     @contextmanager
     def atomic_operation(self):
         """Context manager for thread-safe state mutations."""
@@ -191,3 +197,15 @@ class AppState:
         """Thread-safe update of chat history for a session."""
         with self._lock:
             self.chat_history_store[session_id].append(message)
+
+    # ------------------------------------------------------------------
+    # Memory guardian management
+    # ------------------------------------------------------------------
+
+    @property
+    def memory_guardian(self):
+        """Lazy-initialize and return the MemoryGuardian instance."""
+        if self._memory_guardian is None:
+            from .memory_guardian import MemoryGuardian
+            self._memory_guardian = MemoryGuardian(self)
+        return self._memory_guardian

--- a/main.py
+++ b/main.py
@@ -524,7 +524,7 @@ class IllustriousAIStudio:
         
         # Step 1: Stop Memory Guardian
         self.logger.info("🛡️ Stopping Memory Guardian...")
-        stop_memory_guardian()
+        stop_memory_guardian(self.app_state)
         
         # Step 2: Stop API server if running
         if self.api_server and hasattr(self.api_server, 'should_exit'):

--- a/tests/test_memory_guardian_lifecycle.py
+++ b/tests/test_memory_guardian_lifecycle.py
@@ -6,15 +6,18 @@ if os.getcwd() not in sys.path:
 
 def test_guardian_recreated_after_stop():
     from core.state import AppState
-    from core.memory_guardian import start_memory_guardian, stop_memory_guardian
-    from core.memory_guardian import get_memory_guardian
+    from core.memory_guardian import (
+        start_memory_guardian,
+        stop_memory_guardian,
+        get_memory_guardian,
+    )
 
     app_state = AppState()
     assert app_state.ollama_vision_model is None
     guardian1 = start_memory_guardian(app_state)
-    stop_memory_guardian()
+    stop_memory_guardian(app_state)
     guardian2 = start_memory_guardian(app_state)
-    assert guardian1 is not guardian2
-    # ensure global instance matches returned guardian2
-    assert get_memory_guardian() is guardian2
-    stop_memory_guardian()
+    # guardian instance is stored on the state and reused
+    assert guardian1 is guardian2
+    assert get_memory_guardian(app_state) is guardian2
+    stop_memory_guardian(app_state)

--- a/ui/web.py
+++ b/ui/web.py
@@ -2549,7 +2549,7 @@ def create_gradio_app(state: AppState):
             return get_monitor_status(), get_memory_stats_markdown(state)
 
         def stop_guardian_ui():
-            stop_memory_guardian()
+            stop_memory_guardian(state)
             return get_monitor_status(), get_memory_stats_markdown(state)
 
         def set_profile_ui(profile):


### PR DESCRIPTION
## Summary
- manage memory guardian per AppState instance
- update global access helpers to use AppState property
- adjust lifecycle test and dependent calls

## Testing
- `pytest tests/test_memory_profile_runtime.py tests/test_memory_config.py tests/test_memory_guardian_lifecycle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbf8bbcec83288acf01f681e60ac2