### PR TITLE
Add circuit breaker for Ollama requests

### DIFF
--- a/core/circuit.py
+++ b/core/circuit.py
@@ -1,0 +1,52 @@
+# simple circuit breaker implementation
+import time
+from typing import Callable, Any
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when the circuit is open and calls are not allowed."""
+
+
+class CircuitBreaker:
+    """Basic circuit breaker for controlling external API calls."""
+
+    def __init__(
+        self,
+        failure_threshold: int = 3,
+        recovery_timeout: float = 30.0,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._failures = 0
+        self._state = "CLOSED"
+        self._opened_at = 0.0
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    def call(self, func: Callable[[], Any]) -> Any:
+        """Execute a function while enforcing circuit breaker logic."""
+        if self._state == "OPEN":
+            if (time.time() - self._opened_at) < self.recovery_timeout:
+                raise CircuitBreakerOpen("Circuit breaker is open")
+            # allow a trial call in half-open state
+            self._state = "HALF_OPEN"
+        try:
+            result = func()
+        except Exception:
+            self._record_failure()
+            raise
+        else:
+            self._reset()
+            return result
+
+    def _record_failure(self) -> None:
+        self._failures += 1
+        if self._failures >= self.failure_threshold:
+            self._state = "OPEN"
+            self._opened_at = time.time()
+
+    def _reset(self) -> None:
+        self._failures = 0
+        self._state = "CLOSED"

--- a/core/ollama.py
+++ b/core/ollama.py
@@ -50,6 +50,8 @@ from concurrent.futures import ThreadPoolExecutor
 from PIL import Image
 import requests
 
+from .circuit import CircuitBreaker, CircuitBreakerOpen
+
 from .state import AppState
 from .sdxl import generate_image, save_to_gallery, TEMP_DIR
 from .config import CONFIG
@@ -59,6 +61,9 @@ logger = logging.getLogger(__name__)
 
 # Single thread pool for background disk writes
 executor = ThreadPoolExecutor(max_workers=1)
+
+# Circuit breaker for Ollama API requests
+breaker = CircuitBreaker()
 
 # ==================================================================
 # CONSTANTS AND CONFIGURATION
@@ -191,7 +196,9 @@ def init_ollama(state: AppState) -> Optional[str]:
         - Handles network timeouts and connection errors
     """
     try:
-        response = requests.get(f"{CONFIG.ollama_base_url}/api/tags", timeout=5)
+        response = breaker.call(
+            lambda: requests.get(f"{CONFIG.ollama_base_url}/api/tags", timeout=5)
+        )
         if response.status_code != 200:
             logger.error("Ollama server not responding")
             return None
@@ -211,10 +218,12 @@ def init_ollama(state: AppState) -> Optional[str]:
             "messages": [{"role": "user", "content": "Hi"}],
             "stream": False,
         }
-        test_response = requests.post(
-            f"{CONFIG.ollama_base_url}/api/chat",
-            json=test_data,
-            timeout=30,
+        test_response = breaker.call(
+            lambda: requests.post(
+                f"{CONFIG.ollama_base_url}/api/chat",
+                json=test_data,
+                timeout=30,
+            )
         )
         if test_response.status_code == 200:
             state.model_status["ollama"] = True
@@ -234,6 +243,9 @@ def init_ollama(state: AppState) -> Optional[str]:
             
             return target_model
         logger.error("Failed to test Ollama model: %s", test_response.text)
+    except CircuitBreakerOpen:
+        logger.error("Ollama API temporarily unavailable (circuit open)")
+        return None
     except Exception as e:
         logger.error("Failed to initialize Ollama: %s", e)
     state.model_status["ollama"] = False
@@ -269,7 +281,11 @@ def chat_completion(state: AppState, messages: List[dict], temperature: float = 
             "stream": False,
             "options": {"temperature": temperature, "num_predict": max_tokens},
         }
-        response = requests.post(f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60)
+        response = breaker.call(
+            lambda: requests.post(
+                f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+            )
+        )
         if response.status_code == 200:
             result = response.json()
             return result.get("message", {}).get("content", "No response generated")
@@ -278,6 +294,8 @@ def chat_completion(state: AppState, messages: List[dict], temperature: float = 
             f"❌ Chat completion failed: {response.status_code}. "
             "Ensure the Ollama server is reachable."
         )
+    except CircuitBreakerOpen:
+        return "❌ Service temporarily unavailable. Please try again later."
     except Exception as e:
         logger.error("Ollama completion failed: %s", e)
         return (
@@ -437,7 +455,11 @@ def analyze_image(state: AppState, image: Image.Image, question: str = "Describe
             "messages": [{"role": "user", "content": question, "images": [img_base64]}],
             "stream": False,
         }
-        response = requests.post(f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60)
+        response = breaker.call(
+            lambda: requests.post(
+                f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+            )
+        )
         if response.status_code == 200:
             result = response.json()
             return result.get("message", {}).get("content", "No analysis generated")
@@ -446,6 +468,8 @@ def analyze_image(state: AppState, image: Image.Image, question: str = "Describe
             f"❌ Analysis failed: {response.status_code}. "
             "Ensure the Ollama server is reachable."
         )
+    except CircuitBreakerOpen:
+        return "❌ Service temporarily unavailable. Please try again later."
     except Exception as e:
         logger.error("Image analysis failed: %s", e)
         return (


### PR DESCRIPTION
## Summary
- add simple CircuitBreaker implementation
- integrate CircuitBreaker with Ollama API calls

## Testing
- `pip install pillow PyYAML`
- `pytest tests/test_generate_image.py::test_generate_image_no_model tests/test_memory_config.py::test_config_overrides tests/test_parse_resolution.py::test_parse_resolution_empty_string tests/test_chat_history_persistence.py::test_history_saved_and_loaded tests/test_gallery_filters.py::test_save_and_load_gallery_filter -q` *(fails: ModuleNotFoundError: No module named 'diffusers.pipelines')*

------
https://chatgpt.com/codex/tasks/task_e_684dc20ffa948328ba80e4b2cf45523d