### PR TITLE
Implement degradation strategy

### DIFF
--- a/core/degradation.py
+++ b/core/degradation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+@dataclass
+class DegradationStrategy:
+    """Simple degradation strategy for generation parameters."""
+
+    level: int = 0
+    max_level: int = 3
+
+    def degrade(self, width: int, height: int, steps: int) -> tuple[int, int, int]:
+        """Increase degradation level and return adjusted parameters."""
+        if self.level < self.max_level:
+            self.level += 1
+
+        factor = 0.8 ** self.level  # reduce parameters by 20% per level
+        new_width = max(64, int(width * factor))
+        new_height = max(64, int(height * factor))
+        new_steps = max(1, int(steps * factor))
+        return new_width, new_height, new_steps
+
+    def restore(self) -> None:
+        """Reset degradation level to zero."""
+        self.level = 0

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -128,6 +128,8 @@ class ImageGenerator:
 
         width, height, steps = self.check_resources(width, height, steps)
 
+        strategy = getattr(self.state, "degradation_strategy", None)
+
         clear_gpu_memory()
         if callback:
             callback(0, steps)
@@ -187,6 +189,8 @@ class ImageGenerator:
                             "height": height,
                         },
                     )
+                if strategy:
+                    strategy.restore()
                 clear_gpu_memory()
                 return image, f"✅ Image generated successfully! Seed: {actual_seed}"
             except RuntimeError as e:
@@ -196,6 +200,8 @@ class ImageGenerator:
                         attempt + 1, str(e), width, height, steps
                     )
                     clear_gpu_memory()
+                    if strategy:
+                        width, height, steps = strategy.degrade(width, height, steps)
                     width, height, steps = _reduce_settings_for_retry(width, height, steps, attempt)
                     continue
                 if callback:

--- a/core/state.py
+++ b/core/state.py
@@ -27,6 +27,7 @@ import threading
 from contextlib import contextmanager
 
 from .metrics import Metrics
+from .degradation import DegradationStrategy
 
 if TYPE_CHECKING:
     from .sdxl import ModelProtocol
@@ -179,6 +180,9 @@ class AppState:
 
     metrics: Metrics = field(default_factory=Metrics)
     """Runtime metrics for performance monitoring."""
+
+    degradation_strategy: DegradationStrategy = field(default_factory=DegradationStrategy)
+    """Strategy for adaptive degradation when OOM occurs."""
 
     # ==============================================================
     # INTERNAL SYNCHRONIZATION

--- a/server/api.py
+++ b/server/api.py
@@ -300,7 +300,9 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
 
     @app.get("/metrics")
     async def get_metrics(state: AppState = Depends(get_state)):
-        return state.metrics.to_dict()
+        data = state.metrics.to_dict()
+        data["degradation_level"] = state.degradation_strategy.level
+        return data
 
     return app
 


### PR DESCRIPTION
## Summary
- add a `DegradationStrategy` class to manage adaptive lowering of generation settings
- track the strategy in `AppState`
- degrade generation parameters on OOM and restore on success
- expose the current degradation level from the API metrics endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL, yaml, psutil)*

------
https://chatgpt.com/codex/tasks/task_e_684dcd0d1da48328b12744f19921dab9