### PR TITLE
Fix ImageGenerator init check

### DIFF
--- a/ui/web.py
+++ b/ui/web.py
@@ -749,7 +749,8 @@ def create_gradio_app(state: AppState):
 
                         state.last_generation_params = params
 
-                        if 'image_generator' not in state:
+                        # Lazily create the ImageGenerator once per state
+                        if not hasattr(state, "image_generator"):
                             state.image_generator = ImageGenerator(state)
 
                         image, status = state.image_generator.generate(params)


### PR DESCRIPTION
## Summary
- prevent `TypeError` in `ui.web` by using `hasattr`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684dfbbad6748328bb85fab410f9212c