### PR TITLE
Fix Metrics import

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
 import math
+import threading
 
 @dataclass
 class Metrics:


### PR DESCRIPTION
## Summary
- add missing `threading` import in `core/metrics.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684dfca73d50832883f5c16315f1a80f