### PR TITLE
Fix lint warnings for convenience imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,15 +21,15 @@ application state and FastAPI app instance.
 # CORE API AND UI COMPONENTS
 # ==================================================================
 
-from server.api import create_api_app, GenerateImageRequest, ChatRequest, AnalyzeImageRequest, run_mcp_server
-from ui.web import create_gradio_app
+from server.api import create_api_app, GenerateImageRequest, ChatRequest, AnalyzeImageRequest, run_mcp_server  # noqa: F401
+from ui.web import create_gradio_app  # noqa: F401
 from core.state import AppState
 
 # ==================================================================
 # IMAGE GENERATION FUNCTIONALITY (SDXL)
 # ==================================================================
 
-from core.sdxl import (
+from core.sdxl import (  # noqa: F401
     generate_image,        # Main image generation function
     init_sdxl,            # Initialize SDXL model pipeline
     save_to_gallery,      # Save generated images to gallery
@@ -42,7 +42,7 @@ from core.sdxl import (
 # CHAT AND LANGUAGE MODEL FUNCTIONALITY (OLLAMA)
 # ==================================================================
 
-from core.ollama import (
+from core.ollama import (  # noqa: F401
     chat_completion,      # Direct chat completion API
     handle_chat,          # High-level chat handling with history
     generate_prompt,      # AI-assisted prompt generation
@@ -54,7 +54,7 @@ from core.ollama import (
 # MEMORY AND SYSTEM UTILITIES
 # ==================================================================
 
-from core.memory import clear_gpu_memory, get_model_status
+from core.memory import clear_gpu_memory, get_model_status  # noqa: F401
 
 # ==================================================================
 # GLOBAL APPLICATION STATE AND INSTANCES

--- a/app.py
+++ b/app.py
@@ -22,6 +22,8 @@ application state and FastAPI app instance.
 # ==================================================================
 
 from server.api import create_api_app, GenerateImageRequest, ChatRequest, AnalyzeImageRequest, run_mcp_server  # noqa: F401
+# These imports are exposed for external use as part of the module's convenience layer.
+# They allow external scripts and integrations to access core API functionality directly.
 from ui.web import create_gradio_app  # noqa: F401
 from core.state import AppState
 


### PR DESCRIPTION
## Summary
- silence flake8 unused-import warnings in `app.py`

## Testing
- `pip install Pillow PyYAML psutil`
- `pip install httpx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684dfd656750832896678c259d90f1d3