### PR TITLE
Fix duplicated import in test_api_endpoints

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -6,7 +6,6 @@ import types
 import importlib
 import sys
 import pytest
-import base64
 
 def load_app():
     import os


### PR DESCRIPTION
## Summary
- deduplicate `base64` import in `tests/test_api_endpoints.py`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields'; ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e079df1e88328ac69d7c9d5ebc3bc