### PR TITLE
Fix memory pressure comparison

### DIFF
--- a/core/memory_guardian.py
+++ b/core/memory_guardian.py
@@ -27,9 +27,17 @@ logger = logging.getLogger(__name__)
 
 class MemoryPressureLevel(Enum):
     LOW = "low"           # < 70% usage
-    MEDIUM = "medium"     # 70-85% usage  
+    MEDIUM = "medium"     # 70-85% usage
     HIGH = "high"         # 85-95% usage
     CRITICAL = "critical" # > 95% usage
+
+# Ordering of pressure levels for comparison
+PRESSURE_ORDER = {
+    MemoryPressureLevel.LOW: 0,
+    MemoryPressureLevel.MEDIUM: 1,
+    MemoryPressureLevel.HIGH: 2,
+    MemoryPressureLevel.CRITICAL: 3,
+}
 
 @dataclass
 class MemoryStats:
@@ -311,9 +319,16 @@ class MemoryGuardian:
             # Check if pressure was relieved
             time.sleep(1)  # Give time for cleanup to take effect
             new_stats = self.get_memory_stats()
-            if new_stats and new_stats.pressure_level.value < stats.pressure_level.value:
+            if (
+                new_stats
+                and PRESSURE_ORDER[new_stats.pressure_level] < PRESSURE_ORDER[stats.pressure_level]
+            ):
                 self.oom_prevented_count += 1
-                logger.info(f"Memory pressure reduced from {stats.pressure_level.value} to {new_stats.pressure_level.value}")
+                logger.info(
+                    "Memory pressure reduced from %s to %s",
+                    stats.pressure_level.value,
+                    new_stats.pressure_level.value,
+                )
     
     # ======================== Intervention Strategies ========================
     

--- a/tests/test_memory_pressure_detection.py
+++ b/tests/test_memory_pressure_detection.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from datetime import datetime
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+from core.state import AppState
+from core.memory_guardian import MemoryGuardian, MemoryStats, MemoryPressureLevel
+
+
+def _dummy_intervention():
+    return True
+
+
+def make_stats(level: MemoryPressureLevel) -> MemoryStats:
+    return MemoryStats(
+        timestamp=datetime.now(),
+        gpu_total_gb=10,
+        gpu_allocated_gb=5,
+        gpu_reserved_gb=8,
+        gpu_free_gb=2,
+        gpu_usage_percent=80,
+        system_ram_gb=16,
+        system_ram_usage_percent=40,
+        pressure_level=level,
+    )
+
+
+def test_pressure_reduction_detection(monkeypatch):
+    guardian = MemoryGuardian(AppState())
+    guardian.intervention_callbacks[MemoryPressureLevel.HIGH] = [_dummy_intervention]
+
+    start_stats = make_stats(MemoryPressureLevel.HIGH)
+    reduced_stats = make_stats(MemoryPressureLevel.MEDIUM)
+
+    monkeypatch.setattr(guardian, "get_memory_stats", lambda: reduced_stats)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    guardian._handle_memory_pressure(start_stats)
+    assert guardian.oom_prevented_count == 1
+
+    monkeypatch.setattr(guardian, "get_memory_stats", lambda: start_stats)
+    guardian._handle_memory_pressure(start_stats)
+    assert guardian.oom_prevented_count == 1


### PR DESCRIPTION
## Summary
- compare MemoryPressureLevel using a constant order map
- detect memory pressure reduction accurately in `_handle_memory_pressure`
- add regression test for reduced pressure detection

## Testing
- `pytest -q tests/test_memory_pressure_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_684e0935663c832899df17d2f6acdf56