### PR TITLE
Update chat_history_store docstring

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -126,12 +126,13 @@ class AppState:
     )
     """
     Storage for chat conversation history organized by session.
-    
+
     Structure: {session_id: [(user_message, assistant_response), ...]}
-    
-    Each session maintains its own conversation history, allowing
-    multiple concurrent chat sessions with proper context isolation.
-    The history is kept in memory and lost on application restart.
+
+    Each session keeps up to 100 message pairs (``deque(maxlen=100)``).
+    This allows multiple concurrent chat sessions with proper context
+    isolation. The history is kept in memory and lost on application
+    restart.
     """
     
     # ==============================================================


### PR DESCRIPTION
## Summary
- refine AppState chat history docstring with note about maximum entries per session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684e0b3f84648328ba3f255e34573c92