### PR TITLE
Add share flag for Gradio launch

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -125,6 +125,11 @@ python main.py --quick-start --web-port 8080 --open-browser
 python main.py --quick-start
 ```
 
+### Public Share Link
+```bash
+python main.py --share
+```
+
 ### Debug Mode
 ```bash
 python main.py --quick-start --log-level DEBUG

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ python main.py --lazy-load --web-port 8080 --api-port 8081
 # Require authentication and open a browser window
 python main.py --auth user:pass --open-browser
 
+# Create a public shareable link
+python main.py --share
+
 # Enable memory optimizations
 python main.py --optimize-memory
 ```

--- a/launch.py
+++ b/launch.py
@@ -167,6 +167,7 @@ def main():
             print("  --no-api         : Don't start API server")
             print("  --optimize-memory: Enable memory optimizations")
             print("  --open-browser   : Open browser automatically")
+            print("  --share          : Create a public share link")
             print("  --web-port PORT  : Change web interface port")
             print("  --api-port PORT  : Change API server port")
             

--- a/main.py
+++ b/main.py
@@ -90,10 +90,12 @@ def create_parser() -> argparse.ArgumentParser:
                        help="Do not start API server")
     
     # Security and UI options
-    parser.add_argument("--auth", 
+    parser.add_argument("--auth",
                        help="Gradio auth in user:pass or u1:p1,u2:p2 format")
-    parser.add_argument("--open-browser", action="store_true", 
+    parser.add_argument("--open-browser", action="store_true",
                        help="Open browser automatically on launch")
+    parser.add_argument("--share", action="store_true",
+                       help="Create a public shareable link")
     
     # Performance and debugging
     parser.add_argument("--optimize-memory", action="store_true", 
@@ -315,7 +317,7 @@ class IllustriousAIStudio:
         gradio_app.launch(
             server_name="127.0.0.1",  # Local access only for security
             server_port=self.args.web_port,
-            share=True,  # Enable Gradio sharing for remote access
+            share=self.args.share,  # Enable Gradio sharing if --share is set
             auth=auth,
             show_error=True,  # Show detailed error messages
             inbrowser=self.args.open_browser,  # Auto-open browser if requested

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,79 @@ def stub_dependencies():
                 return types.SimpleNamespace(images=[Image.new('RGB', (64,64), 'white')])
         diff.StableDiffusionXLPipeline = DummyPipe
         sys.modules['diffusers'] = diff
+        pipelines = types.ModuleType('diffusers.pipelines')
+        sdxl_mod = types.ModuleType('diffusers.pipelines.stable_diffusion_xl')
+        submod = types.ModuleType('diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl')
+        submod.StableDiffusionXLPipeline = DummyPipe
+        sys.modules['diffusers.pipelines'] = pipelines
+        sys.modules['diffusers.pipelines.stable_diffusion_xl'] = sdxl_mod
+        sys.modules['diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl'] = submod
+    if 'ui' not in sys.modules:
+        sys.modules['ui'] = types.ModuleType('ui')
+    if 'ui.web' not in sys.modules:
+        web = types.ModuleType('ui.web')
+        def create_gradio_app(state):
+            class DummyApp:
+                def launch(self, *a, **k):
+                    pass
+            return DummyApp()
+        web.create_gradio_app = create_gradio_app
+        sys.modules['ui.web'] = web
+    if 'server' not in sys.modules:
+        sys.modules['server'] = types.ModuleType('server')
+    if 'server.api' not in sys.modules:
+        api = types.ModuleType('server.api')
+        def create_api_app(state):
+            class Dummy:
+                pass
+            return Dummy()
+        api.create_api_app = create_api_app
+        sys.modules['server.api'] = api
+    if 'server.logging_utils' not in sys.modules:
+        log_mod = types.ModuleType('server.logging_utils')
+        class RequestIdFilter:
+            def filter(self, record):
+                return True
+        log_mod.RequestIdFilter = RequestIdFilter
+        log_mod.request_id_var = None
+        sys.modules['server.logging_utils'] = log_mod
+    if 'core' not in sys.modules:
+        sys.modules['core'] = types.ModuleType('core')
+    for mod_name in ['core.sdxl', 'core.ollama', 'core.state', 'core.memory',
+                     'core.memory_guardian', 'core.hardware_profiler']:
+        if mod_name not in sys.modules:
+            module = types.ModuleType(mod_name)
+            if mod_name == 'core.sdxl':
+                def init_sdxl(*a, **k):
+                    pass
+                module.init_sdxl = init_sdxl
+            if mod_name == 'core.ollama':
+                def init_ollama(*a, **k):
+                    pass
+                module.init_ollama = init_ollama
+            if mod_name == 'core.state':
+                class AppState:
+                    pass
+                module.AppState = AppState
+            if mod_name == 'core.memory':
+                def clear_gpu_memory():
+                    pass
+                module.clear_gpu_memory = clear_gpu_memory
+            if mod_name == 'core.memory_guardian':
+                def start_memory_guardian(*a, **k):
+                    pass
+                def stop_memory_guardian():
+                    pass
+                module.start_memory_guardian = start_memory_guardian
+                module.stop_memory_guardian = stop_memory_guardian
+            if mod_name == 'core.hardware_profiler':
+                class HardwareProfiler:
+                    def start(self):
+                        pass
+                    def stop(self):
+                        pass
+                module.HardwareProfiler = HardwareProfiler
+            sys.modules[mod_name] = module
     if 'uvicorn' not in sys.modules:
         sys.modules['uvicorn'] = types.ModuleType('uvicorn')
     if 'requests' not in sys.modules:

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -13,6 +13,7 @@ def test_defaults():
     assert args.no_api is False
     assert args.web_port == 7860
     assert args.api_port == 8000
+    assert args.share is False
     assert args.log_level == "INFO"
     assert args.memory_profile is None
     assert args.memory_threshold is None
@@ -21,11 +22,12 @@ def test_defaults():
 def test_flags_and_ports():
     from main import create_parser
     parser = create_parser()
-    args = parser.parse_args(["--lazy-load", "--no-api", "--web-port", "9000", "--api-port", "1234"])
+    args = parser.parse_args(["--lazy-load", "--no-api", "--web-port", "9000", "--api-port", "1234", "--share"])
     assert args.lazy_load is True
     assert args.no_api is True
     assert args.web_port == 9000
     assert args.api_port == 1234
+    assert args.share is True
 
 def test_memory_cli_options():
     from main import create_parser


### PR DESCRIPTION
## Summary
- expose a new `--share` flag in `create_parser`
- use `args.share` when launching Gradio
- document the new option in README and quick start guide
- show flag in launcher help
- extend CLI tests and stub modules for import

## Testing
- `pytest tests/test_main_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e0f12c5d88328886706548d2778d8