### PR TITLE
Add shortcut for simple mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ pytest
 - **Resolution Selector**: Choose from 7 optimized resolutions (512x512 to 1024x1024, portrait/landscape)
 - Enter prompts or use "Enhance Prompt" for AI improvement
 - Press **Ctrl+Enter** (or **Cmd+Enter** on macOS) to generate
+- Toggle **Simple Mode** with **Ctrl+M** (or **Cmd+M** on macOS)
 - Adjust parameters: steps, guidance scale, seed
 - Images auto-saved to gallery
 - **New**: Use saved prompt templates for consistent results

--- a/ui/enhanced.js
+++ b/ui/enhanced.js
@@ -38,4 +38,16 @@
     else if(status.startsWith('❌')) type = 'error';
     window.showToast(status, type);
   };
+
+  // Keyboard shortcut: Ctrl/Cmd + M toggles simple mode
+  document.addEventListener('keydown', function(e){
+    if((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'm'){
+      const wrapper = document.getElementById('simple-mode-toggle');
+      const checkbox = wrapper ? wrapper.querySelector('input[type="checkbox"]') : null;
+      if(checkbox){
+        checkbox.click();
+        e.preventDefault();
+      }
+    }
+  });
 })();

--- a/ui/enhanced.js
+++ b/ui/enhanced.js
@@ -42,10 +42,9 @@
   // Keyboard shortcut: Ctrl/Cmd + M toggles simple mode
   document.addEventListener('keydown', function(e){
     if((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'm'){
-      const wrapper = document.getElementById('simple-mode-toggle');
-      const checkbox = wrapper ? wrapper.querySelector('input[type="checkbox"]') : null;
+      const checkbox = document.getElementById('simple-mode-checkbox');
       if(checkbox){
-        checkbox.click();
+        checkbox.checked = !checkbox.checked;
         e.preventDefault();
       }
     }

--- a/ui/web.py
+++ b/ui/web.py
@@ -648,6 +648,7 @@ def create_gradio_app(state: AppState):
                     value=state.simple_mode,
                     label="Simple Mode",
                     interactive=True,
+                    elem_id="simple-mode-toggle",
                 )
                 with gr.Row():
                     project_selector = gr.Dropdown(


### PR DESCRIPTION
## Summary
- add keyboard shortcut to toggle simple mode
- expose the simple mode checkbox with an element id
- document the new Ctrl+M shortcut in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e13383bac8328af4ba18b46108299