### PR TITLE
Add gallery export feature

### DIFF
--- a/core/sdxl.py
+++ b/core/sdxl.py
@@ -45,6 +45,7 @@ import os
 import tempfile
 import uuid
 import time
+import zipfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple, List, Dict, TypedDict, Protocol, Callable, Any
@@ -249,6 +250,20 @@ def save_to_gallery(state: AppState, image: Image.Image, prompt: str, metadata: 
     with open(metadata_file, "w") as f:
         json.dump(metadata_info, f, indent=2)
     return str(filepath)
+
+
+def export_gallery(state: AppState, export_path: Path | None = None) -> str:
+    """Bundle the active gallery directory into a ZIP archive."""
+    gallery_dir = _get_active_gallery_dir(state)
+    if export_path is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        export_path = TEMP_DIR / f"gallery_{timestamp}.zip"
+
+    with zipfile.ZipFile(export_path, "w") as zf:
+        for file in gallery_dir.glob("*"):
+            if file.is_file():
+                zf.write(file, arcname=file.name)
+    return str(export_path)
 
 def generate_image(state: AppState, params: GenerationParams) -> Tuple[Optional[Image.Image], str]:
     """Convenience wrapper around ImageGenerator with timing."""

--- a/tests/test_export_gallery.py
+++ b/tests/test_export_gallery.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import json
+import zipfile
+from pathlib import Path
+from PIL import Image
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
+
+
+def test_export_gallery_contains_images_and_metadata(tmp_path, monkeypatch):
+    import importlib, importlib.util, types
+    for mod in ['core.sdxl', 'core.state', 'core.memory', 'core.memory_guardian', 'core']:
+        sys.modules.pop(mod, None)
+    monkeypatch.syspath_prepend(os.getcwd())
+    pkg = types.ModuleType('core')
+    pkg.__path__ = [os.path.join(os.getcwd(), 'core')]
+    sys.modules['core'] = pkg
+    sys.modules['core.image_generator'] = types.ModuleType('core.image_generator')
+    sys.modules['core.image_generator'].ImageGenerator = object
+    spec = importlib.util.spec_from_file_location('core.sdxl', os.path.join('core', 'sdxl.py'))
+    sdxl = importlib.util.module_from_spec(spec)
+    sdxl.SDXLConfig = type('SDXLConfig', (), {})
+    sys.modules['core.sdxl'] = sdxl
+    spec.loader.exec_module(sdxl)
+    state_mod = importlib.import_module('core.state')
+    AppState = state_mod.AppState
+
+    gallery_dir = tmp_path / "gallery"
+    monkeypatch.setattr(sdxl, "GALLERY_DIR", gallery_dir)
+
+    state = AppState()
+    img1 = Image.new("RGB", (10, 10), color="red")
+    img2 = Image.new("RGB", (10, 10), color="blue")
+    path1 = Path(sdxl.save_to_gallery(state, img1, "prompt1"))
+    path2 = Path(sdxl.save_to_gallery(state, img2, "prompt2"))
+
+    zip_path = Path(sdxl.export_gallery(state))
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = set(zf.namelist())
+        for img_path in [path1, path2]:
+            assert img_path.name in names
+            meta_name = img_path.with_suffix(".json").name
+            assert meta_name in names
+            with zf.open(meta_name) as f:
+                data = json.load(f)
+                assert "prompt" in data

--- a/ui/web.py
+++ b/ui/web.py
@@ -554,9 +554,12 @@ def create_gradio_app(state: AppState):
         """Export the current gallery as a ZIP archive."""
         try:
             return export_gallery(state)
-        except Exception as e:  # pragma: no cover - unexpected errors
-            logger.error("Failed to export gallery: %s", e)
+        except (IOError, OSError, zipfile.BadZipFile) as e:  # Handle specific errors
+            logger.error("Failed to export gallery due to a file-related error: %s", e)
             return None
+        except Exception as e:  # Log and re-raise unexpected errors
+            logger.error("Unexpected error during gallery export: %s", e)
+            raise
 
     def list_projects():
         PROJECTS_DIR.mkdir(exist_ok=True)

--- a/ui/web.py
+++ b/ui/web.py
@@ -65,6 +65,7 @@ from core.sdxl import (
     switch_sdxl_model,
     PROJECTS_DIR,
     save_to_gallery,
+    export_gallery,
 )
 from core.image_generator import ImageGenerator
 
@@ -548,6 +549,14 @@ def create_gradio_app(state: AppState):
     def copy_image_path(path: str):
         """Return the path for clipboard copy via JS."""
         return path
+
+    def export_gallery_action():
+        """Export the current gallery as a ZIP archive."""
+        try:
+            return export_gallery(state)
+        except Exception as e:  # pragma: no cover - unexpected errors
+            logger.error("Failed to export gallery: %s", e)
+            return None
 
     def list_projects():
         PROJECTS_DIR.mkdir(exist_ok=True)
@@ -1269,6 +1278,18 @@ def create_gradio_app(state: AppState):
                                 copy_path_btn = gr.Button(
                                     "📋 Copy Path",
                                     variant="secondary",
+                                    elem_classes=["secondary-button"]
+                                )
+                            with gr.Row():
+                                export_gallery_btn = gr.Button(
+                                    "📦 Export Gallery",
+                                    variant="secondary",
+                                    elem_classes=["secondary-button"]
+                                )
+                                export_gallery_download = gr.DownloadButton(
+                                    "💾 Download ZIP",
+                                    variant="secondary",
+                                    visible=False,
                                     elem_classes=["secondary-button"]
                                 )
                             with gr.Row():
@@ -2559,6 +2580,12 @@ def create_gradio_app(state: AppState):
             fn=open_image_file,
             inputs=selected_path,
             outputs=action_status,
+        )
+        export_gallery_btn.click(
+            fn=export_gallery_action,
+            outputs=export_gallery_download,
+        ).then(
+            js=toast_js("Gallery exported", "success")
         )
         try:
             copy_path_btn.click(


### PR DESCRIPTION
## Summary
- add gallery export helper to SDXL module
- expose a Gallery export button in UI
- download gallery as a ZIP archive
- test gallery export helper

## Testing
- `pytest tests/test_export_gallery.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e17da24288328b8f88c513b199328