### PR TITLE
Add project rename support

### DIFF
--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -143,7 +143,6 @@ def test_project_rename(monkeypatch, tmp_path):
     dummy_gr = types.ModuleType('gr')
     dummy_gr.update = lambda *a, **k: None
     monkeypatch.setattr(web, 'gr', dummy_gr)
-    monkeypatch.setattr(web.sdxl, 'PROJECTS_DIR', tmp_path)
     monkeypatch.setattr(web, 'PROJECTS_DIR', tmp_path)
 
     (tmp_path / 'old' / 'gallery').mkdir(parents=True)

--- a/ui/web.py
+++ b/ui/web.py
@@ -2965,7 +2965,7 @@ def rename_project(state: AppState, old_name: str | None, new_name: str):
         shutil.move(str(old_path), str(new_path))
     except Exception as e:  # pragma: no cover - unexpected errors
         logger.error("Failed to rename project %s to %s: %s", old_name, new_name, e)
-        return gr.update(), f"Failed to rename project: {e}"
+        return gr.update(), "An error occurred while renaming the project."
     if state.current_project == old_name:
         state.current_project = new_name
         current_value = new_name


### PR DESCRIPTION
## Summary
- implement `rename_project` helper in `ui/web.py`
- expose rename controls in the UI
- update callbacks to use the new function
- add tests for project renaming behaviour

## Testing
- `pytest tests/test_model_loader.py::test_project_rename -q`

------
https://chatgpt.com/codex/tasks/task_e_684e177dfa50832887562a153827db93