### PR TITLE
Add pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,23 @@
+name: Pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-bugbear"]

--- a/COMPREHENSIVE_DEVELOPMENT_GUIDE.md
+++ b/COMPREHENSIVE_DEVELOPMENT_GUIDE.md
@@ -337,7 +337,7 @@ git checkout -b feature/your-feature-name
 # 3. Install in development mode
 pip install -e .
 
-# 4. Install pre-commit hooks (optional but recommended)
+# 4. Install pre-commit hooks
 pip install pre-commit
 pre-commit install
 ```
@@ -423,6 +423,20 @@ def init_sdxl(config: SDXLConfig) -> StableDiffusionXLPipeline:
         ModelLoadError: If model fails to load
     """
 ```
+
+### Linting & Formatting
+
+The project uses **pre-commit** to run [Black](https://github.com/psf/black) and
+[Flake8](https://flake8.pycqa.org) on all commits. Hooks are installed during
+the [development environment setup](#setting-up-your-development-environment).
+
+```bash
+# Manually run all checks
+pre-commit run --all-files
+```
+
+These checks also run automatically in CI. Ensure your changes pass locally
+before opening a pull request.
 
 ### Logging and Debugging
 


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black and flake8
- run pre-commit in CI
- document how to run linting in the development guide

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/pre-commit.yml COMPREHENSIVE_DEVELOPMENT_GUIDE.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684e1ee0ff58832886e88fe57a321c67