### PR TITLE
Add mypy configuration and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-test.txt
+      - name: Run mypy
+        run: mypy

--- a/mcp_servers/git_server.py
+++ b/mcp_servers/git_server.py
@@ -6,6 +6,7 @@ Provides Git repository operations and information.
 
 import asyncio
 import logging
+import os
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -299,7 +300,7 @@ def git_remote_info(repo_path: str = str(BASE_DIR)) -> List[Dict[str, str]]:
     return remotes
 
 @mcp.tool()
-def git_file_history(repo_path: str = str(BASE_DIR), filename: str, max_count: int = 10) -> List[Dict[str, Any]]:
+def git_file_history(filename: str, repo_path: str = str(BASE_DIR), max_count: int = 10) -> List[Dict[str, Any]]:
     """
     Get the commit history for a specific file.
     

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.10
+ignore_missing_imports = True
+warn_unused_ignores = True
+strict_optional = True
+disallow_untyped_defs = True
+check_untyped_defs = True
+files = mcp_servers/git_server.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ pytest>=7.0
 Pillow>=9.0.0,<11.0.0
 PyYAML>=6.0,<7.0
 httpx>=0.27
+mypy>=1.7
 


### PR DESCRIPTION
## Summary
- configure mypy with a dedicated `mypy.ini`
- fix argument order and missing import in `git_server.py`
- add mypy to test requirements
- run mypy in new `ci.yml` workflow

## Testing
- `pytest -q`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_684e1ef905f083288001c9842f8a3436