### PR TITLE
Fix missing os import for server files

### DIFF
--- a/mcp_servers/filesystem_server.py
+++ b/mcp_servers/filesystem_server.py
@@ -6,9 +6,9 @@ Provides secure filesystem operations with configurable access controls.
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
-import os
 
 from mcp.server.fastmcp import FastMCP
 

--- a/mcp_servers/filesystem_server.py
+++ b/mcp_servers/filesystem_server.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
+import os
 
 from mcp.server.fastmcp import FastMCP
 

--- a/mcp_servers/image_analysis_server.py
+++ b/mcp_servers/image_analysis_server.py
@@ -10,6 +10,7 @@ import io
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import os
 
 from PIL import Image, ImageStat
 import torch


### PR DESCRIPTION
## Summary
- import os where missing in filesystem and image analysis servers
- ensure os.getenv calls work without NameError
- run partial tests

## Testing
- `pytest tests/test_main_cli.py::test_defaults -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e204b036083288c9976130bccb184