### PR TITLE
Add sys.path fixture for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
 import sys
 import types
+from pathlib import Path
 import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def add_project_root_to_path():
+    """Prepend the project root directory to ``sys.path`` for tests."""
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    try:
+        yield
+    finally:
+        if str(root) in sys.path:
+            sys.path.remove(str(root))
 
 @pytest.fixture(scope="session", autouse=True)
 def stub_dependencies():

--- a/tests/test_analyze_image_validation.py
+++ b/tests/test_analyze_image_validation.py
@@ -1,9 +1,5 @@
-import os
 import sys
 from PIL import Image
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 from core.state import AppState
 import types

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -8,9 +8,7 @@ import sys
 import pytest
 
 def load_app():
-    import os
-    if os.getcwd() not in sys.path:
-        sys.path.insert(0, os.getcwd())
+    
     if 'gradio' not in sys.modules:
         sys.modules['gradio'] = types.ModuleType('gradio')
     if 'diffusers' not in sys.modules:

--- a/tests/test_chat_history_persistence.py
+++ b/tests/test_chat_history_persistence.py
@@ -1,11 +1,8 @@
 import json
-import sys
-import os
 
 import pytest
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
+
 
 
 

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 import pytest
 
 from core import config

--- a/tests/test_export_gallery.py
+++ b/tests/test_export_gallery.py
@@ -5,9 +5,6 @@ import zipfile
 from pathlib import Path
 from PIL import Image
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 
 def test_export_gallery_contains_images_and_metadata(tmp_path, monkeypatch):
     import importlib, importlib.util, types

--- a/tests/test_gallery_filters.py
+++ b/tests/test_gallery_filters.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 from pathlib import Path
 
 # Removed global modification of sys.path

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -5,9 +5,6 @@ import sys
 import pytest
 
 def load_app():
-    import os
-    if os.getcwd() not in sys.path:
-        sys.path.insert(0, os.getcwd())
     if 'gradio' not in sys.modules:
         sys.modules['gradio'] = types.ModuleType('gradio')
     if 'diffusers' not in sys.modules:

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,10 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
-
 def test_defaults():
     from main import create_parser
     parser = create_parser()

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 from core.config import CONFIG
 
 

--- a/tests/test_memory_guardian_lifecycle.py
+++ b/tests/test_memory_guardian_lifecycle.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 def test_guardian_recreated_after_stop():
     from core.state import AppState
     from core.memory_guardian import (

--- a/tests/test_memory_manager_cli.py
+++ b/tests/test_memory_manager_cli.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 from memory_manager import create_parser
 
 

--- a/tests/test_memory_pressure_detection.py
+++ b/tests/test_memory_pressure_detection.py
@@ -1,9 +1,5 @@
-import os
-import sys
 from datetime import datetime
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 from core.state import AppState
 from core.memory_guardian import MemoryGuardian, MemoryStats, MemoryPressureLevel

--- a/tests/test_memory_profile_runtime.py
+++ b/tests/test_memory_profile_runtime.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 from core.state import AppState
 from core.memory_guardian import MemoryGuardian, PROFILE_PRESETS
 

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -3,9 +3,6 @@ import types
 
 def test_model_loader_button(monkeypatch):
     events = {}
-    import os, sys
-    if os.getcwd() not in sys.path:
-        sys.path.insert(0, os.getcwd())
     import ui.web as web
     from core.state import AppState
 

--- a/tests/test_parse_resolution.py
+++ b/tests/test_parse_resolution.py
@@ -1,8 +1,4 @@
-import os
 import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 import importlib
 import types

--- a/tests/test_prompt_analyzer.py
+++ b/tests/test_prompt_analyzer.py
@@ -1,9 +1,3 @@
-import sys
-import os
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 from core.prompt_analyzer import analyze_prompt
 
 

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 from core.prompt_templates import PromptTemplateManager
 
 

--- a/tests/test_save_gallery.py
+++ b/tests/test_save_gallery.py
@@ -1,10 +1,7 @@
 import os
-import sys
 from pathlib import Path
 from PIL import Image
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 
 def test_save_to_gallery_creates_directory(tmp_path, monkeypatch):

--- a/tests/test_server_memory_guardian.py
+++ b/tests/test_server_memory_guardian.py
@@ -1,9 +1,5 @@
-import os
 import sys
 import types
-
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 
 def test_guardian_active_on_server_start(monkeypatch):

--- a/tests/test_ui_fix.py
+++ b/tests/test_ui_fix.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import ast
 import importlib.util
 import logging
@@ -7,8 +5,6 @@ import types
 from pathlib import Path
 
 # Ensure project root is on the path for imports
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
 
 
 # The `_stub_core_modules` function has been moved to `conftest.py` as a pytest fixture.


### PR DESCRIPTION
## Summary
- create an autouse fixture to prepend project root to `sys.path`
- remove inline `sys.path` editing from tests

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e24d241b88328b65b759c4c09c00f