### PR TITLE
Refactor core module stubbing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 import types
+from pathlib import Path
 import pytest
 
 @pytest.fixture(scope="session", autouse=True)
@@ -131,3 +132,103 @@ def stub_dependencies():
         requests.get = dummy_get
         requests.post = dummy_post
         sys.modules['requests'] = requests
+
+
+def stub_core_modules():
+    """Provide stubs for core modules used in tests."""
+    # Ensure any placeholder ui modules from stub_dependencies do not interfere
+    for mod in ['ui.web', 'ui']:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    core_pkg = types.ModuleType('core')
+    sys.modules.setdefault('core', core_pkg)
+
+    sdxl = types.ModuleType('core.sdxl')
+    sdxl.generate_image = lambda *a, **k: None
+    sdxl.generate_with_notifications = lambda *a, **k: None
+    sdxl.TEMP_DIR = Path('/tmp')
+    sdxl.get_latest_image = lambda *a, **k: None
+    sdxl.init_sdxl = lambda *a, **k: None
+    sdxl.get_available_models = lambda *a, **k: []
+    sdxl.get_current_model_info = lambda *a, **k: {}
+    sdxl.test_model_generation = lambda *a, **k: None
+    sdxl.switch_sdxl_model = lambda *a, **k: None
+    sdxl.save_to_gallery = lambda *a, **k: None
+    sdxl.export_gallery = lambda *a, **k: None
+    sdxl.PROJECTS_DIR = Path('/tmp')
+    sys.modules['core.sdxl'] = sdxl
+    setattr(core_pkg, 'sdxl', sdxl)
+
+    config = types.ModuleType('core.config')
+    config.CONFIG = {}
+    sys.modules['core.config'] = config
+    setattr(core_pkg, 'config', config)
+
+    state = types.ModuleType('core.state')
+    class DummyState:
+        ...
+    state.AppState = DummyState
+    sys.modules['core.state'] = state
+    setattr(core_pkg, 'state', state)
+
+    ollama = types.ModuleType('core.ollama')
+    ollama.generate_prompt = lambda *a, **k: None
+    ollama.handle_chat = lambda *a, **k: None
+    ollama.analyze_image = lambda *a, **k: None
+    ollama.init_ollama = lambda *a, **k: None
+    sys.modules['core.ollama'] = ollama
+    setattr(core_pkg, 'ollama', ollama)
+
+    ig = types.ModuleType('core.image_generator')
+    class ImageGenerator:
+        pass
+    ig.ImageGenerator = ImageGenerator
+    sys.modules['core.image_generator'] = ig
+    setattr(core_pkg, 'image_generator', ig)
+
+    gp = types.ModuleType('core.generation_presets')
+    gp.GENERATION_PRESETS = {}
+    gp.DEFAULT_PRESET = {}
+    sys.modules['core.generation_presets'] = gp
+    setattr(core_pkg, 'generation_presets', gp)
+
+    memory = types.ModuleType('core.memory')
+    memory.get_model_status = lambda *a, **k: None
+    memory.get_memory_stats_markdown = lambda *a, **k: None
+    memory.get_memory_stats_wrapper = lambda *a, **k: None
+    sys.modules['core.memory'] = memory
+    setattr(core_pkg, 'memory', memory)
+
+    mg = types.ModuleType('core.memory_guardian')
+    mg.start_memory_guardian = lambda *a, **k: None
+    mg.stop_memory_guardian = lambda *a, **k: None
+    mg.get_memory_guardian = lambda *a, **k: None
+    sys.modules['core.memory_guardian'] = mg
+    setattr(core_pkg, 'memory_guardian', mg)
+
+    pt = types.ModuleType('core.prompt_templates')
+    pt.template_manager = None
+    sys.modules['core.prompt_templates'] = pt
+    setattr(core_pkg, 'prompt_templates', pt)
+
+    pa = types.ModuleType('core.prompt_analyzer')
+    pa.analyze_prompt = lambda *a, **k: None
+    class PromptAnalyzer:
+        pass
+    pa.PromptAnalyzer = PromptAnalyzer
+    pa.auto_enhance_prompt = lambda *a, **k: None
+    sys.modules['core.prompt_analyzer'] = pa
+    setattr(core_pkg, 'prompt_analyzer', pa)
+
+    gf = types.ModuleType('core.gallery_filters')
+    gf.load_gallery_filter = lambda *a, **k: None
+    gf.save_gallery_filter = lambda *a, **k: None
+    sys.modules['core.gallery_filters'] = gf
+    setattr(core_pkg, 'gallery_filters', gf)
+
+
+@pytest.fixture
+def stub_core_modules_fixture():
+    stub_core_modules()
+    yield
+

--- a/tests/test_parse_resolution.py
+++ b/tests/test_parse_resolution.py
@@ -5,82 +5,9 @@ if os.getcwd() not in sys.path:
     sys.path.insert(0, os.getcwd())
 
 import importlib
-import types
 from pathlib import Path
 
-
-def stub_core_modules():
-    core_pkg = types.ModuleType('core')
-    sys.modules.setdefault('core', core_pkg)
-
-    sdxl = types.ModuleType('core.sdxl')
-    sdxl.generate_image = lambda *a, **k: None
-    sdxl.generate_with_notifications = lambda *a, **k: None
-    sdxl.TEMP_DIR = Path('/tmp')
-    sdxl.get_latest_image = lambda *a, **k: None
-    sdxl.init_sdxl = lambda *a, **k: None
-    sdxl.get_available_models = lambda *a, **k: []
-    sdxl.get_current_model_info = lambda *a, **k: {}
-    sdxl.test_model_generation = lambda *a, **k: None
-    sdxl.switch_sdxl_model = lambda *a, **k: None
-    sdxl.PROJECTS_DIR = Path('/tmp')
-    sys.modules['core.sdxl'] = sdxl
-    setattr(core_pkg, 'sdxl', sdxl)
-
-    config = types.ModuleType('core.config')
-    config.CONFIG = {}
-    sys.modules['core.config'] = config
-    setattr(core_pkg, 'config', config)
-
-    state = types.ModuleType('core.state')
-    class DummyState: ...
-    state.AppState = DummyState
-    sys.modules['core.state'] = state
-    setattr(core_pkg, 'state', state)
-
-    ollama = types.ModuleType('core.ollama')
-    ollama.generate_prompt = lambda *a, **k: None
-    ollama.handle_chat = lambda *a, **k: None
-    ollama.analyze_image = lambda *a, **k: None
-    ollama.init_ollama = lambda *a, **k: None
-    sys.modules['core.ollama'] = ollama
-    setattr(core_pkg, 'ollama', ollama)
-
-    gp = types.ModuleType('core.generation_presets')
-    gp.GENERATION_PRESETS = {}
-    gp.DEFAULT_PRESET = {}
-    sys.modules['core.generation_presets'] = gp
-    setattr(core_pkg, 'generation_presets', gp)
-
-    memory = types.ModuleType('core.memory')
-    memory.get_model_status = lambda *a, **k: None
-    memory.get_memory_stats_markdown = lambda *a, **k: None
-    memory.get_memory_stats_wrapper = lambda *a, **k: None
-    sys.modules['core.memory'] = memory
-    setattr(core_pkg, 'memory', memory)
-
-    mg = types.ModuleType('core.memory_guardian')
-    mg.start_memory_guardian = lambda *a, **k: None
-    mg.stop_memory_guardian = lambda *a, **k: None
-    mg.get_memory_guardian = lambda *a, **k: None
-    sys.modules['core.memory_guardian'] = mg
-    setattr(core_pkg, 'memory_guardian', mg)
-
-    pt = types.ModuleType('core.prompt_templates')
-    pt.template_manager = None
-    sys.modules['core.prompt_templates'] = pt
-    setattr(core_pkg, 'prompt_templates', pt)
-
-    pa = types.ModuleType('core.prompt_analyzer')
-    pa.analyze_prompt = lambda *a, **k: None
-    sys.modules['core.prompt_analyzer'] = pa
-    setattr(core_pkg, 'prompt_analyzer', pa)
-
-    gf = types.ModuleType('core.gallery_filters')
-    gf.load_gallery_filter = lambda *a, **k: None
-    gf.save_gallery_filter = lambda *a, **k: None
-    sys.modules['core.gallery_filters'] = gf
-    setattr(core_pkg, 'gallery_filters', gf)
+from conftest import stub_core_modules
 
 
 def load_web_module():

--- a/tests/test_ui_fix.py
+++ b/tests/test_ui_fix.py
@@ -4,6 +4,8 @@ import ast
 import importlib.util
 import logging
 import types
+
+from conftest import stub_core_modules
 from pathlib import Path
 
 # Ensure project root is on the path for imports
@@ -11,11 +13,11 @@ if os.getcwd() not in sys.path:
     sys.path.insert(0, os.getcwd())
 
 
-# The `_stub_core_modules` function has been moved to `conftest.py` as a pytest fixture.
-# Use the `stub_core_modules` fixture in test functions as needed.
+# The `stub_core_modules` helper is defined in `conftest.py`.
+# Import and call it in test helpers or tests as needed.
 def _parse_resolution():
     """Load the parse_resolution function from ui/web.py without importing the entire module."""
-    _stub_core_modules()
+    stub_core_modules()
     file_path = Path(__file__).resolve().parent.parent / "ui" / "web.py"
     source = file_path.read_text()
     tree = ast.parse(source, filename=str(file_path))


### PR DESCRIPTION
## Summary
- add a shared `stub_core_modules` helper and fixture in `tests/conftest.py`
- reuse that helper in `test_parse_resolution` and `test_ui_fix`

## Testing
- `pytest tests/test_parse_resolution.py tests/test_ui_fix.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e2b6ad02c8328a0d70662f354ff38