### PR TITLE
Fix memory_manager imports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,19 +345,19 @@ The **Memory Guardian** provides automatic OOM prevention with real-time monitor
 
 ```bash
 # Monitor memory status
-python memory_manager.py --status
+python -m memory_manager --status
 
 # Interactive memory monitoring
-python memory_manager.py --monitor
+python -m memory_manager --monitor
 
 # Generate comprehensive memory report
-python memory_manager.py --report
+python -m memory_manager --report
 
 # Test memory pressure handling
-python memory_manager.py --test-pressure critical
+python -m memory_manager --test-pressure critical
 
 # Clear GPU memory manually
-python memory_manager.py --clear
+python -m memory_manager --clear
 ```
 
 **Key Features:**
@@ -387,7 +387,7 @@ python test_memory_guardian.py
 ### Troubleshooting GPU OOM
 With Memory Guardian active, OOM issues should be automatically prevented. If you still encounter problems:
 
-1. Check Memory Guardian status: `python memory_manager.py --status`
+1. Check Memory Guardian status: `python -m memory_manager --status`
 2. Run `python model_manager.py --image-mode` before generating
 3. Reduce image size or steps
 4. Check GPU usage with `nvidia-smi` (CUDA) or `rocm-smi`/`rocminfo` (ROCm)

--- a/TROUBLESHOOTING_GUIDE.md
+++ b/TROUBLESHOOTING_GUIDE.md
@@ -115,7 +115,7 @@ If you still encounter CUDA OOM errors:
 
 #### **If Problems Persist**:
 1. Check logs: `tail -f logs/illustrious_ai_studio.log`
-2. Clear GPU memory: `python memory_manager.py --clear`
+2. Clear GPU memory: `python -m memory_manager --clear`
 3. Restart with fresh models: `python main.py --lazy-load`
 4. Run the test suite: `python test_ui_fix.py`
 
@@ -129,7 +129,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 #### **Memory Pressure Testing**
 ```bash
-python memory_manager.py --test-pressure critical
+python -m memory_manager --test-pressure critical
 ```
 
 #### **Model Validation**

--- a/agent.md
+++ b/agent.md
@@ -376,7 +376,7 @@ python main.py --lazy-load --open-browser
 python -m pytest tests/ -v
 
 # Check system status
-python memory_manager.py
+python -m memory_manager
 
 # Clean up and optimize
 find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
@@ -386,7 +386,7 @@ find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 
 | Problem | Instant Fix |
 |---------|-------------|
-| **Out of Memory** | Use task: `🔍 Memory Status` → Then `python memory_manager.py --clear` |
+| **Out of Memory** | Use task: `🔍 Memory Status` → Then `python -m memory_manager --clear` |
 | **Models Not Loading** | Use task: `📦 Setup Environment` → Then restart |
 | **Web UI Won't Start** | Try different port: `python main.py --port 7861` |
 | **Slow Generation** | Check GPU: `nvidia-smi` → Reduce batch size in config |

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -7,10 +7,6 @@ Comprehensive memory management and OOM prevention tool
 import argparse
 import sys
 import time
-from pathlib import Path
-
-# Add the current directory to Python path for imports
-sys.path.insert(0, str(Path(__file__).parent))
 
 from core.memory_guardian import get_memory_guardian, MemoryPressureLevel
 from core.state import AppState


### PR DESCRIPTION
## Summary
- remove custom path hack from `memory_manager.py`
- use `python -m memory_manager` in documentation
- update troubleshooting guide and agent instructions
- verify memory manager CLI via tests

## Testing
- `python -m pytest -q tests/test_memory_manager_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684e36ffd894832887d3da1558d1df7c