### PR TITLE
Add MAX_IMAGE_PIXELS constant and tests

### DIFF
--- a/core/ollama.py
+++ b/core/ollama.py
@@ -70,6 +70,9 @@ breaker = CircuitBreaker()
 # CONSTANTS AND CONFIGURATION
 # ==================================================================
 
+# Maximum number of pixels allowed for image analysis (16MP)
+MAX_IMAGE_PIXELS = 16_000_000
+
 # File for persistent chat history storage
 CHAT_HISTORY_FILE = Path(TEMP_DIR) / "chat_history.json"
 
@@ -459,7 +462,8 @@ def analyze_image(
     try:
         width, height = image.size
         if width * height > MAX_IMAGE_PIXELS:
-            return "❌ Image exceeds 16MP limit."
+            limit_mp = MAX_IMAGE_PIXELS // 1_000_000
+            return f"❌ Image exceeds {limit_mp}MP limit."
         if width > 1920 or height > 1920:
             image = image.copy()
             image.thumbnail((1920, 1920), Image.Resampling.LANCZOS)

--- a/tests/test_analyze_image_validation.py
+++ b/tests/test_analyze_image_validation.py
@@ -6,22 +6,29 @@ import types
 
 
 def load_analyze_image():
-    if 'core.sdxl' not in sys.modules:
-        dummy = types.ModuleType('core.sdxl')
-        dummy.generate_image = lambda *a, **k: None
-        dummy.save_to_gallery = lambda *a, **k: None
-        dummy.TEMP_DIR = '/tmp'
-        sys.modules['core.sdxl'] = dummy
-    return __import__('core.ollama', fromlist=['analyze_image']).analyze_image
+    if 'core.sdxl' in sys.modules:
+        del sys.modules['core.sdxl']
+    dummy = types.ModuleType('core.sdxl')
+    dummy.generate_image = lambda *a, **k: None
+    dummy.save_to_gallery = lambda *a, **k: None
+    dummy.TEMP_DIR = '/tmp'
+    sys.modules['core.sdxl'] = dummy
+    if 'core.ollama' in sys.modules:
+        del sys.modules['core.ollama']
+    module = __import__('core.ollama', fromlist=['analyze_image', 'MAX_IMAGE_PIXELS'])
+    return module.analyze_image, module.MAX_IMAGE_PIXELS
 
 
 def test_analyze_image_rejects_large_image():
-    analyze_image = load_analyze_image()
+    analyze_image, MAX_IMAGE_PIXELS = load_analyze_image()
 
     state = AppState()
     state.model_status["multimodal"] = True
     state.ollama_vision_model = "dummy"
 
-    img = Image.new("RGB", (5000, 4000))  # 20MP > 16MP
+    width = 4000
+    height = MAX_IMAGE_PIXELS // width + 1
+    img = Image.new("RGB", (width, height))
     result = analyze_image(state, img)
-    assert result.startswith("❌") and "16MP" in result
+    expected = f"{MAX_IMAGE_PIXELS // 1_000_000}MP"
+    assert result.startswith("❌") and expected in result


### PR DESCRIPTION
## Summary
- set `MAX_IMAGE_PIXELS` in `core/ollama.py`
- reference the constant when validating image size
- update analyze-image tests to use the constant

## Testing
- `pytest tests/test_analyze_image_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e36b4eb0c8328bda1bf9a3c46d89b