### PR TITLE
Refactor circuit breaker usage and add test

### DIFF
--- a/core/ollama.py
+++ b/core/ollama.py
@@ -201,11 +201,10 @@ def init_ollama(state: AppState) -> Optional[str]:
     """
     start_time = time.perf_counter()
     try:
-        response = call_with_circuit_breaker(
-            breaker,
-            requests.get,
-            f"{CONFIG.ollama_base_url}/api/tags",
-            timeout=5
+        response = breaker.call(
+            lambda: requests.get(
+                f"{CONFIG.ollama_base_url}/api/tags", timeout=5
+            )
         )
         if response.status_code != 200:
             logger.error("Ollama server not responding")


### PR DESCRIPTION
## Summary
- replace `call_with_circuit_breaker` with direct `breaker.call`
- cover circuit breaker handling in `init_ollama`

## Testing
- `PYTHONPATH=. pytest tests/test_config_and_init.py::test_init_ollama_circuit_breaker -q`
- `PYTHONPATH=. pytest -q` *(fails: ERROR tests/test_full_functionality.py)*

------
https://chatgpt.com/codex/tasks/task_e_684e3842b4008328a3ebabde9b30c3eb