### PR TITLE
Fix conda python detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,16 @@ class IllustriousSetup:
         """Get python executable path for conda environment."""
         if platform.system() == "Windows":
             # Try multiple possible locations on Windows
-            conda_info, _ = subprocess.run([self.conda_exe, "info", "--json"], 
-                                          capture_output=True, text=True).stdout, None
+            result = subprocess.run([
+                self.conda_exe,
+                "info",
+                "--json",
+            ], capture_output=True, text=True)
+            conda_info = result.stdout
+            if result.returncode != 0:
+                self.print_status("error", f"Failed to get conda info: {result.stderr}")
+                self.errors.append("Failed to get conda info")
+                conda_info = ""
             if conda_info:
                 try:
                     info = json.loads(conda_info)

--- a/tests/test_setup_get_env_python.py
+++ b/tests/test_setup_get_env_python.py
@@ -1,0 +1,26 @@
+import types
+import platform
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "setup_script", Path(__file__).resolve().parents[1] / "setup.py"
+)
+setup_script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(setup_script)
+IllustriousSetup = setup_script.IllustriousSetup
+
+
+def test_get_env_python_returns_path(monkeypatch):
+    args = types.SimpleNamespace(verbose=False)
+    setup = IllustriousSetup(args)
+    setup.conda_exe = '/usr/bin/conda'
+
+    def fake_run_command(cmd, **kwargs):
+        return True, '/tmp/env/bin/python\n'
+
+    monkeypatch.setattr(setup, 'run_command', fake_run_command)
+    monkeypatch.setattr(platform, 'system', lambda: 'Linux')
+
+    python_path = setup.get_env_python()
+    assert python_path == '/tmp/env/bin/python'


### PR DESCRIPTION
## Summary
- improve subprocess handling in `get_env_python`
- add regression test for `get_env_python`

## Testing
- `pytest tests/test_setup_get_env_python.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core', 'torch', 'httpx', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e41d11f24832882c58b3b0132a103