### PR TITLE
Document server package exports

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,23 @@
+"""API server package for Illustrious AI Studio.
+
+This package bundles the components required to run the Model Context Protocol
+(MCP) API server. It exposes helpers for constructing the FastAPI application
+and launching the server, along with utilities for asynchronous task
+processing and structured logging.
+
+Modules
+-------
+api
+    FastAPI application factory and server entry point. Provides
+    :func:`create_api_app` and :func:`run_mcp_server`.
+
+tasks
+    Celery task definitions used for background image generation.
+
+logging_utils
+    Utilities for attaching per-request identifiers to log messages.
+"""
+
+from .api import create_api_app, run_mcp_server
+
+__all__ = ["create_api_app", "run_mcp_server"]


### PR DESCRIPTION
## Summary
- document API server components in `server/__init__.py`
- expose `create_api_app` and `run_mcp_server` in `__all__`

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e4911f0bc8328be5377fe9e0e9d87