### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r requirements-test.txt
           pip install coverage pytest-cov
       - name: Run pytest
-        run: pytest --cov=. --cov-report=xml -vv --cov-fail-under=$COVERAGE_THRESHOLD
+        run: pytest --cov=. --cov-report=xml -vv --cov-fail-under="$COVERAGE_THRESHOLD"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- install `coverage` and `pytest-cov`
- run `pytest --cov=. --cov-report=xml`
- upload `coverage.xml` as an artifact
- allow optional coverage threshold via `$COVERAGE_THRESHOLD`

## Testing
- `pytest --cov=. --cov-report=xml -vv --cov-fail-under=0` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684e4caa06d48328ae8fbc05325006f0