### PR TITLE
Switch ollama to async client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Pillow>=9.0.0,<11.0.0
 
 # Ollama Integration (if using local LLM server)
 requests>=2.28.0,<3.0.0
+httpx>=0.27
 PyYAML>=6.0,<7.0
 
 # Optional: Direct LLM integration (alternative to Ollama)

--- a/src/illustrious_ai_studio/app.py
+++ b/src/illustrious_ai_studio/app.py
@@ -51,11 +51,11 @@ from .core.sdxl import (  # noqa: F401
 # ==================================================================
 
 from .core.ollama import (  # noqa: F401
-    chat_completion,      # Direct chat completion API
+    chat_completion_sync as chat_completion,  # Direct chat completion API
     handle_chat,          # High-level chat handling with history
     generate_prompt,      # AI-assisted prompt generation
-    analyze_image,        # Multi-modal image analysis
-    init_ollama,          # Initialize Ollama connection and models
+    analyze_image_sync as analyze_image,  # Multi-modal image analysis
+    init_ollama_sync as init_ollama,      # Initialize Ollama connection and models
 )
 
 # ==================================================================

--- a/src/illustrious_ai_studio/core/ollama.py
+++ b/src/illustrious_ai_studio/core/ollama.py
@@ -43,14 +43,15 @@ import io
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Callable
+from typing import Any, Dict, List, Optional, Tuple, Callable, Awaitable
 from collections import deque
 from typing import Deque
 from concurrent.futures import ThreadPoolExecutor
 import time
 
 from PIL import Image
-import requests
+import httpx
+import asyncio
 
 from .circuit import CircuitBreaker, CircuitBreakerOpen
 
@@ -68,7 +69,7 @@ executor = ThreadPoolExecutor(max_workers=1)
 breaker = CircuitBreaker()
 
 
-def call_with_retries(func: Callable[[], requests.Response], retries: int = 3, delay: float = 1.0) -> requests.Response:
+def call_with_retries(func: Callable[[], httpx.Response], retries: int = 3, delay: float = 1.0) -> httpx.Response:
     """Execute func via breaker.call with simple retry logic."""
     for attempt in range(retries):
         try:
@@ -80,6 +81,22 @@ def call_with_retries(func: Callable[[], requests.Response], retries: int = 3, d
                 raise
             logger.warning("Request failed. Retrying %d/%d", attempt + 1, retries)
             time.sleep(delay)
+
+
+async def call_with_retries_async(
+    func: Callable[[], Awaitable[httpx.Response]], retries: int = 3, delay: float = 1.0
+) -> httpx.Response:
+    """Async version of call_with_retries using breaker.call_async."""
+    for attempt in range(retries):
+        try:
+            return await breaker.call_async(func)
+        except CircuitBreakerOpen:
+            raise
+        except Exception:
+            if attempt >= retries - 1:
+                raise
+            logger.warning("Request failed. Retrying %d/%d", attempt + 1, retries)
+            await asyncio.sleep(delay)
 
 # ==================================================================
 # CONSTANTS AND CONFIGURATION
@@ -194,7 +211,7 @@ def save_chat_history_async(state: AppState) -> None:
 # OLLAMA MODEL INITIALIZATION AND MANAGEMENT
 # ==================================================================
 
-def init_ollama(state: AppState) -> Optional[str]:
+async def init_ollama(state: AppState) -> Optional[str]:
     """
     Initialize Ollama connection and verify model availability.
     
@@ -216,9 +233,10 @@ def init_ollama(state: AppState) -> Optional[str]:
     """
     start_time = time.perf_counter()
     try:
-        response = call_with_retries(
-            lambda: requests.get(f"{CONFIG.ollama_base_url}/api/tags", timeout=5)
-        )
+        async with httpx.AsyncClient() as client:
+            response = await call_with_retries_async(
+                lambda: client.get(f"{CONFIG.ollama_base_url}/api/tags", timeout=5)
+            )
         if response.status_code != 200:
             logger.error("Ollama server not responding")
             return None
@@ -238,13 +256,14 @@ def init_ollama(state: AppState) -> Optional[str]:
             "messages": [{"role": "user", "content": "Hi"}],
             "stream": False,
         }
-        test_response = breaker.call(
-            lambda: requests.post(
-                f"{CONFIG.ollama_base_url}/api/chat",
-                json=test_data,
-                timeout=30,
+        async with httpx.AsyncClient() as client:
+            test_response = await breaker.call_async(
+                lambda: client.post(
+                    f"{CONFIG.ollama_base_url}/api/chat",
+                    json=test_data,
+                    timeout=30,
+                )
             )
-        )
         if test_response.status_code == 200:
             state.model_status["ollama"] = True
             state.ollama_model = target_model
@@ -286,10 +305,10 @@ def switch_ollama_model(state: AppState, name: str) -> bool:
     save_chat_history_async(state)
     CONFIG.ollama_model = name
     logger.info("Switching Ollama model to %s", name)
-    return init_ollama(state) is not None
+    return init_ollama_sync(state) is not None
 
 
-def chat_completion(state: AppState, messages: List[dict], temperature: float = 0.7, max_tokens: int = 256) -> str:
+async def chat_completion(state: AppState, messages: List[dict], temperature: float = 0.7, max_tokens: int = 256) -> str:
     if not state.ollama_model:
         return (
             "❌ Ollama model not loaded. Please check your Ollama setup. "
@@ -302,11 +321,12 @@ def chat_completion(state: AppState, messages: List[dict], temperature: float = 
             "stream": False,
             "options": {"temperature": temperature, "num_predict": max_tokens},
         }
-        response = breaker.call(
-            lambda: requests.post(
-                f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+        async with httpx.AsyncClient() as client:
+            response = await breaker.call_async(
+                lambda: client.post(
+                    f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+                )
             )
-        )
         if response.status_code == 200:
             result = response.json()
             return result.get("message", {}).get("content", "No response generated")
@@ -336,7 +356,7 @@ def generate_prompt(state: AppState, user_input: str) -> str:
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": user_input},
     ]
-    enhanced = chat_completion(state, messages, temperature=0.8)
+    enhanced = chat_completion_sync(state, messages, temperature=0.8)
     return enhanced if not enhanced.startswith("❌") else user_input
 
 
@@ -374,7 +394,7 @@ def generate_creative_prompt(state: AppState, user_input: str, style: str = "enh
         {"role": "user", "content": f"Create a prompt for: {user_input}"},
     ]
 
-    enhanced = chat_completion(state, messages, temperature=0.9, max_tokens=150)
+    enhanced = chat_completion_sync(state, messages, temperature=0.9, max_tokens=150)
     return enhanced if not enhanced.startswith("❌") else user_input
 
 
@@ -442,7 +462,7 @@ def handle_chat(state: AppState, message: str, session_id: str = "default", chat
                 {"role": "assistant", "content": msg[1]},
             ])
         messages.append({"role": "user", "content": message})
-        response = chat_completion(state, messages)
+        response = chat_completion_sync(state, messages)
         if "<think>" in response and "</think>" in response:
             parts = response.split("</think>")
             if len(parts) > 1:
@@ -455,7 +475,7 @@ def handle_chat(state: AppState, message: str, session_id: str = "default", chat
     return chat_history, ""
 
 
-def analyze_image(
+async def analyze_image(
     state: AppState, image: Image.Image | str | io.IOBase, question: str = "Describe this image in detail"
 ) -> str:
     if not image:
@@ -490,11 +510,12 @@ def analyze_image(
             "messages": [{"role": "user", "content": question, "images": [img_base64]}],
             "stream": False,
         }
-        response = breaker.call(
-            lambda: requests.post(
-                f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+        async with httpx.AsyncClient() as client:
+            response = await breaker.call_async(
+                lambda: client.post(
+                    f"{CONFIG.ollama_base_url}/api/chat", json=data, timeout=60
+                )
             )
-        )
         if response.status_code == 200:
             result = response.json()
             return result.get("message", {}).get("content", "No analysis generated")
@@ -511,3 +532,27 @@ def analyze_image(
             f"❌ Analysis failed: {e}. "
             "Ensure the Ollama server is running."
         )
+
+
+def init_ollama_sync(state: AppState) -> Optional[str]:
+    """Synchronous wrapper for init_ollama."""
+    return asyncio.run(init_ollama(state))
+
+
+def chat_completion_sync(
+    state: AppState,
+    messages: List[dict],
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+) -> str:
+    """Synchronous wrapper for chat_completion."""
+    return asyncio.run(chat_completion(state, messages, temperature, max_tokens))
+
+
+def analyze_image_sync(
+    state: AppState,
+    image: Image.Image | str | io.IOBase,
+    question: str = "Describe this image in detail",
+) -> str:
+    """Synchronous wrapper for analyze_image."""
+    return asyncio.run(analyze_image(state, image, question))

--- a/src/illustrious_ai_studio/main.py
+++ b/src/illustrious_ai_studio/main.py
@@ -31,7 +31,7 @@ from .server.logging_utils import RequestIdFilter
 
 # Core functionality
 from .core.sdxl import init_sdxl
-from .core.ollama import init_ollama
+from .core.ollama import init_ollama_sync as init_ollama
 from .core.state import AppState
 from .core.memory import clear_gpu_memory
 from .core.memory_guardian import start_memory_guardian, stop_memory_guardian

--- a/src/illustrious_ai_studio/server/api.py
+++ b/src/illustrious_ai_studio/server/api.py
@@ -148,7 +148,7 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
             if state.sdxl_pipe is None:
                 sdxl.init_sdxl(state)
             if state.ollama_model is None:
-                ollama.init_ollama(state)
+                await ollama.init_ollama(state)
 
     @app.get("/status")
     async def server_status(state: AppState = Depends(get_state)):
@@ -239,7 +239,7 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
                 detail="Ollama model not available. Is the Ollama server running?",
             )
         messages = [{"role": "user", "content": request.message}]
-        response = chat_completion(state, messages, request.temperature, request.max_tokens)
+        response = await chat_completion(state, messages, request.temperature, request.max_tokens)
         return {"response": response, "session_id": request.session_id}
 
     @app.post("/analyze-image")
@@ -257,7 +257,7 @@ def create_api_app(state: AppState, auto_load: bool = True) -> FastAPI:
                 status_code=400,
                 detail=f"Invalid image data: {e}. Ensure the input is valid base64.",
             )
-        analysis = analyze_image(state, image, request.question)
+        analysis = await analyze_image(state, image, request.question)
         return {"analysis": analysis}
 
     @app.post("/switch-models")

--- a/src/illustrious_ai_studio/ui/web.py
+++ b/src/illustrious_ai_studio/ui/web.py
@@ -77,7 +77,12 @@ from ..core.config import CONFIG
 from ..core.state import AppState
 
 # Chat and language model functionality  
-from ..core.ollama import generate_prompt, handle_chat, analyze_image, init_ollama
+from ..core.ollama import (
+    generate_prompt,
+    handle_chat,
+    analyze_image_sync as analyze_image,
+    init_ollama_sync as init_ollama,
+)
 from ..core import sdxl, ollama
 from ..core.generation_presets import GENERATION_PRESETS, DEFAULT_PRESET
 
@@ -2737,7 +2742,7 @@ def create_gradio_app(state: AppState):
             if load_s:
                 sdxl.init_sdxl(state)
             if load_o or load_v:
-                ollama.init_ollama(state)
+                ollama.init_ollama_sync(state)
             return (
                 get_model_status(state),
                 get_memory_stats_markdown(state),

--- a/tests/test_analyze_image_validation.py
+++ b/tests/test_analyze_image_validation.py
@@ -15,8 +15,8 @@ def load_analyze_image():
     sys.modules['core.sdxl'] = dummy
     if 'core.ollama' in sys.modules:
         del sys.modules['core.ollama']
-    module = __import__('core.ollama', fromlist=['analyze_image', 'MAX_IMAGE_PIXELS'])
-    return module.analyze_image, module.MAX_IMAGE_PIXELS
+    module = __import__('core.ollama', fromlist=['analyze_image_sync', 'MAX_IMAGE_PIXELS'])
+    return module.analyze_image_sync, module.MAX_IMAGE_PIXELS
 
 
 def test_analyze_image_rejects_large_image():

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -45,10 +45,10 @@ class DummyPipe:
     def generate(self, *args, **kwargs):
         return types.SimpleNamespace(images=[Image.new('RGB', (64, 64), 'blue')])
 
-def dummy_chat_completion(messages, temperature=0.7, max_tokens=256):
+async def dummy_chat_completion(messages, temperature=0.7, max_tokens=256):
     return "ok"
 
-def dummy_analyze_image(image, question=""): 
+async def dummy_analyze_image(image, question=""):
     return "blue"
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_and_init.py
+++ b/tests/test_config_and_init.py
@@ -46,10 +46,22 @@ def test_init_ollama_no_model(monkeypatch):
         def json(self):
             return {"models": [{"name": "other"}]}
 
-    monkeypatch.setattr(ollama.requests, "get", lambda *a, **k: Resp())
-    monkeypatch.setattr(ollama.requests, "post", lambda *a, **k: Resp())
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *a, **k):
+            return Resp()
+
+        async def post(self, *a, **k):
+            return Resp()
+
+    monkeypatch.setattr(ollama.httpx, "AsyncClient", lambda *a, **k: DummyClient())
     monkeypatch.setattr(ollama.CONFIG, "ollama_model", "missing")
-    result = ollama.init_ollama(state)
+    result = ollama.init_ollama_sync(state)
     assert result is None
     assert state.model_status["ollama"] is False
 
@@ -67,11 +79,23 @@ def test_init_ollama_no_name_error(monkeypatch):
         def json(self):
             return {"models": [{"name": ollama.CONFIG.ollama_model}]}
 
-    monkeypatch.setattr(ollama.requests, "get", lambda *a, **k: Resp())
-    monkeypatch.setattr(ollama.requests, "post", lambda *a, **k: Resp())
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *a, **k):
+            return Resp()
+
+        async def post(self, *a, **k):
+            return Resp()
+
+    monkeypatch.setattr(ollama.httpx, "AsyncClient", lambda *a, **k: DummyClient())
     monkeypatch.setattr(ollama, "load_chat_history", lambda st: None)
 
     try:
-        ollama.init_ollama(state)
+        ollama.init_ollama_sync(state)
     except NameError as e:
         pytest.fail(f"init_ollama raised NameError: {e}")

--- a/tests/test_full_functionality.py
+++ b/tests/test_full_functionality.py
@@ -27,7 +27,11 @@ init(autoreset=True)
 # Import our modules
 from illustrious_ai_studio.core.state import AppState
 from illustrious_ai_studio.core.sdxl import init_sdxl, generate_image
-from illustrious_ai_studio.core.ollama import init_ollama, generate_prompt, analyze_image
+from illustrious_ai_studio.core.ollama import (
+    init_ollama_sync as init_ollama,
+    generate_prompt,
+    analyze_image_sync as analyze_image,
+)
 from illustrious_ai_studio.core.memory import get_model_status
 from illustrious_ai_studio.core.config import CONFIG
 

--- a/tests/test_model_switching.py
+++ b/tests/test_model_switching.py
@@ -45,7 +45,7 @@ def test_switch_ollama_model(monkeypatch):
     def dummy_init(st):
         st.ollama_model = CONFIG.ollama_model
         return CONFIG.ollama_model
-    monkeypatch.setattr(ollama, "init_ollama", dummy_init)
+    monkeypatch.setattr(ollama, "init_ollama_sync", dummy_init)
 
     res = ollama.switch_ollama_model(state, "new-model")
     assert res is True

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -30,7 +30,11 @@ if shutil.which('ollama') is None:
 # Import our modules
 from illustrious_ai_studio.core.state import AppState
 from illustrious_ai_studio.core.sdxl import init_sdxl, generate_image
-from illustrious_ai_studio.core.ollama import init_ollama, generate_prompt, analyze_image
+from illustrious_ai_studio.core.ollama import (
+    init_ollama_sync as init_ollama,
+    generate_prompt,
+    analyze_image_sync as analyze_image,
+)
 from illustrious_ai_studio.core.memory import clear_gpu_memory
 
 


### PR DESCRIPTION
## Summary
- convert init_ollama, chat_completion and analyze_image to async functions
- add async circuit breaker support
- use httpx.AsyncClient for all Ollama requests
- provide blocking wrappers for old synchronous code
- update FastAPI server to await Ollama operations
- fix imports and tests to use new wrappers
- include httpx runtime dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684e590cff2c8328a35d45b347df447d