### PR TITLE
Centralize logging configuration

### DIFF
--- a/src/illustrious_ai_studio/app.py
+++ b/src/illustrious_ai_studio/app.py
@@ -17,6 +17,13 @@ The module exposes all major components and provides a pre-configured
 application state and FastAPI app instance.
 """
 
+import logging
+
+from .core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
+
 # ==================================================================
 # CORE API AND UI COMPONENTS
 # ==================================================================

--- a/src/illustrious_ai_studio/app.py
+++ b/src/illustrious_ai_studio/app.py
@@ -21,7 +21,6 @@ import logging
 
 from .core.logging_utils import configure_logging
 
-configure_logging("INFO")
 logger = logging.getLogger(__name__)
 
 # ==================================================================

--- a/src/illustrious_ai_studio/core/logging_utils.py
+++ b/src/illustrious_ai_studio/core/logging_utils.py
@@ -1,0 +1,41 @@
+import logging
+import logging.handlers
+from pathlib import Path
+
+from ..server.logging_utils import RequestIdFilter
+
+
+def configure_logging(level: str) -> None:
+    """Configure root logging handlers and level."""
+    root = logging.getLogger()
+    root.setLevel(level.upper())
+
+    has_file_handler = any(isinstance(h, logging.handlers.RotatingFileHandler) for h in root.handlers)
+    if not has_file_handler:
+        log_dir = Path("logs")
+        log_dir.mkdir(exist_ok=True)
+
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_dir / "illustrious_ai_studio.log",
+            maxBytes=10 * 1024 * 1024,
+            backupCount=5,
+        )
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(request_id)s - %(message)s"
+        )
+        file_handler.setFormatter(formatter)
+        file_handler.addFilter(RequestIdFilter())
+
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(
+            logging.Formatter("%(levelname)s: %(message)s [%(request_id)s]")
+        )
+        console_handler.addFilter(RequestIdFilter())
+
+        root.addHandler(file_handler)
+        root.addHandler(console_handler)
+
+    # Reduce noise from third-party libraries
+    logging.getLogger("gradio").setLevel(logging.INFO)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/src/illustrious_ai_studio/mcp_servers/filesystem_server.py
+++ b/src/illustrious_ai_studio/mcp_servers/filesystem_server.py
@@ -12,9 +12,10 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from mcp.server.fastmcp import FastMCP
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("filesystem-server")
+from ..core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
 
 # Initialize the FastMCP server
 mcp = FastMCP("Filesystem Server")

--- a/src/illustrious_ai_studio/mcp_servers/git_server.py
+++ b/src/illustrious_ai_studio/mcp_servers/git_server.py
@@ -13,9 +13,10 @@ from typing import Any, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("git-server")
+from ..core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
 
 # Initialize the FastMCP server
 mcp = FastMCP("Git Server")

--- a/src/illustrious_ai_studio/mcp_servers/image_analysis_server.py
+++ b/src/illustrious_ai_studio/mcp_servers/image_analysis_server.py
@@ -16,9 +16,10 @@ from PIL import Image, ImageStat
 import torch
 from mcp.server.fastmcp import FastMCP
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("image-analysis-server")
+from ..core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
 
 # Initialize the FastMCP server
 mcp = FastMCP("Image Analysis Server")

--- a/src/illustrious_ai_studio/mcp_servers/manager.py
+++ b/src/illustrious_ai_studio/mcp_servers/manager.py
@@ -16,9 +16,10 @@ from typing import Dict, List, Optional, Any
 import threading
 import time
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("mcp-manager")
+from ..core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
 
 class MCPServerManager:
     """Manages multiple MCP servers."""

--- a/src/illustrious_ai_studio/mcp_servers/web_fetch_server.py
+++ b/src/illustrious_ai_studio/mcp_servers/web_fetch_server.py
@@ -20,9 +20,10 @@ from markdownify import markdownify as md
 
 from mcp.server.fastmcp import FastMCP
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("web-fetch-server")
+from ..core.logging_utils import configure_logging
+
+configure_logging("INFO")
+logger = logging.getLogger(__name__)
 
 # Initialize the FastMCP server
 mcp = FastMCP("Web Fetch Server")

--- a/tests/test_full_functionality.py
+++ b/tests/test_full_functionality.py
@@ -17,8 +17,10 @@ if torch is None:
     pytest.skip("torch not available", allow_module_level=True)
 from colorama import init, Fore, Style
 
+from illustrious_ai_studio.core.logging_utils import configure_logging
+
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+configure_logging("INFO")
 logger = logging.getLogger(__name__)
 
 # Initialize colorama for colored output

--- a/tests/test_ui_fix.py
+++ b/tests/test_ui_fix.py
@@ -1,6 +1,9 @@
 import ast
 import importlib.util
 import logging
+from illustrious_ai_studio.core.logging_utils import configure_logging
+
+configure_logging("INFO")
 import types
 
 from conftest import stub_core_modules


### PR DESCRIPTION
## Summary
- centralize logging configuration in `core.logging_utils.configure_logging`
- use new helper in `main.py` and `app.py`
- update mcp server scripts to share the same logging setup
- update tests to initialize logging through the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684e5c13e06483289851b450aeea8845