### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,26 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3
+
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        language_version: python3
+
   - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.2.0
     hooks:
       - id: flake8
         additional_dependencies: ["flake8-bugbear"]
+        language_version: python3
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.16.0
+    hooks:
+      - id: mypy
+        args: ["--install-types", "--non-interactive"]
+        language_version: python3

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -188,6 +188,28 @@ All code follows comprehensive commenting standards:
 - Concurrent request handling
 - Caching of expensive operations
 
+### Pre-commit Hooks
+
+Code style and static analysis are enforced with `pre-commit`. Install the tool
+and set up the Git hook by running:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Update hook versions with:
+
+```bash
+pre-commit autoupdate
+```
+
+You can manually run all checks using:
+
+```bash
+pre-commit run --all-files
+```
+
 ## 🔍 Debugging and Troubleshooting
 
 ### Logging System


### PR DESCRIPTION
## Summary
- include black, isort, flake8, and mypy in `.pre-commit-config.yaml`
- document how to use pre-commit in the developer guide
- run `pre-commit autoupdate` to pin versions

## Testing
- `pre-commit run --files .pre-commit-config.yaml DEVELOPER_GUIDE.md`

------
https://chatgpt.com/codex/tasks/task_e_684e5e37c38c8328b68706ae09a35f28